### PR TITLE
Fix 1-site `tdvp` when `reverse_step=false`

### DIFF
--- a/examples/05_utils.jl
+++ b/examples/05_utils.jl
@@ -3,7 +3,7 @@ using ITensorTDVP
 using Observers
 using Printf
 
-using ITensorTDVP: tdvp_solver, process_sweeps, TDVPOrder
+using ITensorTDVP: tdvp_solver, tdvp_step, process_sweeps, TDVPOrder
 
 function tdvp_nonuniform_timesteps(
   solver,
@@ -22,7 +22,7 @@ function tdvp_nonuniform_timesteps(
   current_time = time_start
   for sw in 1:nsweeps
     sw_time = @elapsed begin
-      psi, PH, info = tdvp(
+      psi, PH, info = tdvp_step(
         tdvp_order,
         solver,
         PH,

--- a/src/tdvp_generic.jl
+++ b/src/tdvp_generic.jl
@@ -79,7 +79,7 @@ function tdvp(solver, PH, t::Number, psi0::MPS; kwargs...)
     end
 
     sw_time = @elapsed begin
-      psi, PH, info = tdvp(
+      psi, PH, info = tdvp_step(
         tdvp_order,
         solver,
         PH,

--- a/src/tdvp_step.jl
+++ b/src/tdvp_step.jl
@@ -1,5 +1,4 @@
-# TODO: Rename `tdvp_step`?
-function tdvp(
+function tdvp_step(
   order::TDVPOrder, solver, PH, time_step::Number, psi::MPS; current_time=0.0, kwargs...
 )
   orderings = ITensorTDVP.orderings(order)
@@ -7,7 +6,7 @@ function tdvp(
   sub_time_steps *= time_step
   global info
   for substep in 1:length(sub_time_steps)
-    psi, PH, info = tdvp(
+    psi, PH, info = tdvp_sweep(
       orderings[substep], solver, PH, sub_time_steps[substep], psi; current_time, kwargs...
     )
     current_time += sub_time_steps[substep]
@@ -32,20 +31,18 @@ is_forward_done(direction::Base.ReverseOrdering, b, n; ncenter) = false
 is_reverse_done(direction::Base.ForwardOrdering, b, n; ncenter) = false
 is_reverse_done(direction::Base.ReverseOrdering, b, n; ncenter) = (b == 1)
 function is_half_sweep_done(direction, b, n; ncenter)
-  return is_forward_done(direction, b, n; ncenter) || is_reverse_done(direction, b, n; ncenter)
+  return is_forward_done(direction, b, n; ncenter) ||
+         is_reverse_done(direction, b, n; ncenter)
 end
 
-# TODO: Rename `tdvp_sweep`?
-function tdvp(direction::Base.Ordering, solver, PH, time_step::Number, psi::MPS; kwargs...)
+function tdvp_sweep(direction::Base.Ordering, solver, PH, time_step::Number, psi::MPS; kwargs...)
   PH = copy(PH)
   psi = copy(psi)
-
   if length(psi) == 1
     error(
       "`tdvp` currently does not support system sizes of 1. You can diagonalize the MPO tensor directly with tools like `LinearAlgebra.eigen`, `KrylovKit.exponentiate`, etc.",
     )
   end
-
   nsite::Int = get(kwargs, :nsite, 2)
   reverse_step::Bool = get(kwargs, :reverse_step, true)
   normalize::Bool = get(kwargs, :normalize, false)
@@ -55,12 +52,10 @@ function tdvp(direction::Base.Ordering, solver, PH, time_step::Number, psi::MPS;
   outputlevel = get(kwargs, :outputlevel, 0)
   sw = get(kwargs, :sweep, 1)
   current_time = get(kwargs, :current_time, 0.0)
-
   maxdim::Integer = get(kwargs, :maxdim, typemax(Int))
   mindim::Integer = get(kwargs, :mindim, 1)
   cutoff::Real = get(kwargs, :cutoff, 1E-16)
   noise::Real = get(kwargs, :noise, 0.0)
-
   N = length(psi)
   set_nsite!(PH, nsite)
   if isforward(direction)
@@ -76,94 +71,34 @@ function tdvp(direction::Base.Ordering, solver, PH, time_step::Number, psi::MPS;
     @assert(isortho(psi) && (orthocenter(psi) == N - nsite + 1))
     position!(PH, psi, N - nsite + 1)
   end
-
   maxtruncerr = 0.0
   for b in sweep_bonds(direction, N; ncenter=nsite)
-    # Do 'forwards' evolution step
-    set_nsite!(PH, nsite)
-    position!(PH, psi, b)
-    if nsite == 1
-      phi1 = psi[b]
-    elseif nsite == 2
-      phi1 = psi[b] * psi[b + 1]
-    end
-    phi1, info = solver(PH, time_step, phi1; current_time, outputlevel)
-
-    current_time += time_step
-
-    normalize && (phi1 /= norm(phi1))
-
-    spec = nothing
-    if nsite == 1
-      psi[b] = phi1
-    elseif nsite == 2
-      ortho = isforward(direction) ? "left" : "right"
-
-      drho = nothing
-      if noise > 0.0 && isforward(direction)
-        drho = noise * noiseterm(PH, phi, ortho)
-      end
-
-      spec = replacebond!(
-        psi,
-        b,
-        phi1;
-        maxdim,
-        mindim,
-        cutoff,
-        eigen_perturbation=drho,
-        ortho=ortho,
-        normalize,
-        which_decomp,
-        svd_alg,
-      )
-      maxtruncerr = max(maxtruncerr, spec.truncerr)
-    end
-
-    #
-    # Do backwards evolution step
-    #
-    if reverse_step && !is_half_sweep_done(direction, b, N; ncenter=nsite)
-      b1 = (isforward(direction) ? b + 1 : b)
-      Δ = (isforward(direction) ? +1 : -1)
-      if nsite == 2
-        phi0 = psi[b1]
-      elseif nsite == 1
-        uinds = uniqueinds(phi1, psi[b + Δ])
-        U, S, V = svd(phi1, uinds)
-        psi[b] = U
-        phi0 = S * V
-        if isforward(direction)
-          ITensors.setleftlim!(psi, b)
-        elseif isreverse(direction)
-          ITensors.setrightlim!(psi, b)
-        end
-      end
-
-      set_nsite!(PH, nsite - 1)
-      position!(PH, psi, b1)
-
-      phi0, info = solver(PH, -time_step, phi0; current_time, outputlevel)
-
-      current_time -= time_step
-
-      normalize && (phi0 ./= norm(phi0))
-
-      if nsite == 2
-        psi[b1] = phi0
-      elseif nsite == 1
-        psi[b + Δ] = phi0 * psi[b + Δ]
-        if isforward(direction)
-          ITensors.setrightlim!(psi, b + Δ + 1)
-        elseif isreverse(direction)
-          ITensors.setleftlim!(psi, b + Δ - 1)
-        end
-      end
-      set_nsite!(PH, nsite)
-    end
-
+    current_time, maxtruncerr, spec = tdvp_site_update!(
+      solver,
+      PH,
+      psi,
+      b;
+      nsite,
+      reverse_step,
+      current_time,
+      outputlevel,
+      time_step,
+      normalize,
+      direction,
+      noise,
+      which_decomp,
+      svd_alg,
+      cutoff,
+      maxdim,
+      mindim,
+      maxtruncerr,
+    )
     if outputlevel >= 2
-      @printf("Sweep %d, direction %s, bond (%d,%d) \n", sw, direction, b, b + 1)
+      if nsite == 1
+        @printf("Sweep %d, direction %s, bond (%d,) \n", sw, direction, b)
+      elseif nsite == 2
+        @printf("Sweep %d, direction %s, bond (%d,%d) \n", sw, direction, b, b + 1)
+      end
       print("  Truncated using")
       @printf(" cutoff=%.1E", cutoff)
       @printf(" maxdim=%.1E", maxdim)
@@ -177,7 +112,6 @@ function tdvp(direction::Base.Ordering, solver, PH, time_step::Number, psi::MPS;
       end
       flush(stdout)
     end
-
     update!(
       observer;
       psi,
@@ -190,9 +124,288 @@ function tdvp(direction::Base.Ordering, solver, PH, time_step::Number, psi::MPS;
       current_time,
     )
   end
-
   # Just to be sure:
   normalize && normalize!(psi)
-
   return psi, PH, TDVPInfo(maxtruncerr)
+end
+
+function tdvp_site_update!(
+  solver,
+  PH,
+  psi,
+  b;
+  nsite,
+  reverse_step,
+  current_time,
+  outputlevel,
+  time_step,
+  normalize,
+  direction,
+  noise,
+  which_decomp,
+  svd_alg,
+  cutoff,
+  maxdim,
+  mindim,
+  maxtruncerr,
+)
+  return tdvp_site_update!(
+    Val(nsite),
+    Val(reverse_step),
+    solver,
+    PH,
+    psi,
+    b;
+    current_time,
+    outputlevel,
+    time_step,
+    normalize,
+    direction,
+    noise,
+    which_decomp,
+    svd_alg,
+    cutoff,
+    maxdim,
+    mindim,
+    maxtruncerr,
+  )
+end
+
+function tdvp_site_update!(
+  nsite_val::Val{1},
+  reverse_step_val::Val{false},
+  solver,
+  PH,
+  psi,
+  b;
+  current_time,
+  outputlevel,
+  time_step,
+  normalize,
+  direction,
+  noise,
+  which_decomp,
+  svd_alg,
+  cutoff,
+  maxdim,
+  mindim,
+  maxtruncerr,
+)
+  N = length(psi)
+  nsite = 1
+  # Do 'forwards' evolution step
+  set_nsite!(PH, nsite)
+  position!(PH, psi, b)
+  phi1 = psi[b]
+  phi1, info = solver(PH, time_step, phi1; current_time, outputlevel)
+  current_time += time_step
+  normalize && (phi1 /= norm(phi1))
+  spec = nothing
+  psi[b] = phi1
+  if !is_half_sweep_done(direction, b, N; ncenter=nsite)
+    # Move ortho center
+    Δ = (isforward(direction) ? +1 : -1)
+    orthogonalize!(psi, b + Δ)
+  end
+  return current_time, maxtruncerr, spec
+end
+
+function tdvp_site_update!(
+  nsite_val::Val{1},
+  reverse_step_val::Val{true},
+  solver,
+  PH,
+  psi,
+  b;
+  current_time,
+  outputlevel,
+  time_step,
+  normalize,
+  direction,
+  noise,
+  which_decomp,
+  svd_alg,
+  cutoff,
+  maxdim,
+  mindim,
+  maxtruncerr,
+)
+  N = length(psi)
+  nsite = 1
+  # Do 'forwards' evolution step
+  set_nsite!(PH, nsite)
+  position!(PH, psi, b)
+  phi1 = psi[b]
+  phi1, info = solver(PH, time_step, phi1; current_time, outputlevel)
+  current_time += time_step
+  normalize && (phi1 /= norm(phi1))
+  spec = nothing
+  psi[b] = phi1
+  if !is_half_sweep_done(direction, b, N; ncenter=nsite)
+    # Do backwards evolution step
+    b1 = (isforward(direction) ? b + 1 : b)
+    Δ = (isforward(direction) ? +1 : -1)
+    uinds = uniqueinds(phi1, psi[b + Δ])
+    U, S, V = svd(phi1, uinds)
+    psi[b] = U
+    phi0 = S * V
+    if isforward(direction)
+      ITensors.setleftlim!(psi, b)
+    elseif isreverse(direction)
+      ITensors.setrightlim!(psi, b)
+    end
+    set_nsite!(PH, nsite - 1)
+    position!(PH, psi, b1)
+    phi0, info = solver(PH, -time_step, phi0; current_time, outputlevel)
+    current_time -= time_step
+    normalize && (phi0 ./= norm(phi0))
+    psi[b + Δ] = phi0 * psi[b + Δ]
+    if isforward(direction)
+      ITensors.setrightlim!(psi, b + Δ + 1)
+    elseif isreverse(direction)
+      ITensors.setleftlim!(psi, b + Δ - 1)
+    end
+    set_nsite!(PH, nsite)
+  end
+  return current_time, maxtruncerr, spec
+end
+
+function tdvp_site_update!(
+  nsite_val::Val{2},
+  reverse_step_val::Val{false},
+  solver,
+  PH,
+  psi,
+  b;
+  current_time,
+  outputlevel,
+  time_step,
+  normalize,
+  direction,
+  noise,
+  which_decomp,
+  svd_alg,
+  cutoff,
+  maxdim,
+  mindim,
+  maxtruncerr,
+)
+  N = length(psi)
+  nsite = 2
+  # Do 'forwards' evolution step
+  set_nsite!(PH, nsite)
+  position!(PH, psi, b)
+  phi1 = psi[b] * psi[b + 1]
+  phi1, info = solver(PH, time_step, phi1; current_time, outputlevel)
+  current_time += time_step
+  normalize && (phi1 /= norm(phi1))
+  spec = nothing
+  ortho = isforward(direction) ? "left" : "right"
+  drho = nothing
+  if noise > 0.0 && isforward(direction)
+    drho = noise * noiseterm(PH, phi, ortho)
+  end
+  spec = replacebond!(
+    psi,
+    b,
+    phi1;
+    maxdim,
+    mindim,
+    cutoff,
+    eigen_perturbation=drho,
+    ortho=ortho,
+    normalize,
+    which_decomp,
+    svd_alg,
+  )
+  maxtruncerr = max(maxtruncerr, spec.truncerr)
+  return current_time, maxtruncerr, spec
+end
+
+function tdvp_site_update!(
+  nsite_val::Val{2},
+  reverse_step_val::Val{true},
+  solver,
+  PH,
+  psi,
+  b;
+  current_time,
+  outputlevel,
+  time_step,
+  normalize,
+  direction,
+  noise,
+  which_decomp,
+  svd_alg,
+  cutoff,
+  maxdim,
+  mindim,
+  maxtruncerr,
+)
+  N = length(psi)
+  nsite = 2
+  # Do 'forwards' evolution step
+  set_nsite!(PH, nsite)
+  position!(PH, psi, b)
+  phi1 = psi[b] * psi[b + 1]
+  phi1, info = solver(PH, time_step, phi1; current_time, outputlevel)
+  current_time += time_step
+  normalize && (phi1 /= norm(phi1))
+  spec = nothing
+  ortho = isforward(direction) ? "left" : "right"
+  drho = nothing
+  if noise > 0.0 && isforward(direction)
+    drho = noise * noiseterm(PH, phi, ortho)
+  end
+  spec = replacebond!(
+    psi,
+    b,
+    phi1;
+    maxdim,
+    mindim,
+    cutoff,
+    eigen_perturbation=drho,
+    ortho=ortho,
+    normalize,
+    which_decomp,
+    svd_alg,
+  )
+  maxtruncerr = max(maxtruncerr, spec.truncerr)
+  if !is_half_sweep_done(direction, b, N; ncenter=nsite)
+    # Do backwards evolution step
+    b1 = (isforward(direction) ? b + 1 : b)
+    Δ = (isforward(direction) ? +1 : -1)
+    phi0 = psi[b1]
+    set_nsite!(PH, nsite - 1)
+    position!(PH, psi, b1)
+    phi0, info = solver(PH, -time_step, phi0; current_time, outputlevel)
+    current_time -= time_step
+    normalize && (phi0 ./= norm(phi0))
+    psi[b1] = phi0
+    set_nsite!(PH, nsite)
+  end
+  return current_time, maxtruncerr, spec
+end
+
+function tdvp_site_update!(
+  ::Val{nsite},
+  ::Val{reverse_step},
+  solver,
+  PH,
+  psi,
+  b;
+  current_time,
+  outputlevel,
+  time_step,
+  normalize,
+  direction,
+  noise,
+  which_decomp,
+  svd_alg,
+  cutoff,
+  maxdim,
+  mindim,
+  maxtruncerr,
+) where {nsite,reverse_step}
+  return error("`tdvp` with `nsite=$nsite` and `reverse_step=$reverse_step` not implemented.")
 end

--- a/src/tdvp_step.jl
+++ b/src/tdvp_step.jl
@@ -35,7 +35,9 @@ function is_half_sweep_done(direction, b, n; ncenter)
          is_reverse_done(direction, b, n; ncenter)
 end
 
-function tdvp_sweep(direction::Base.Ordering, solver, PH, time_step::Number, psi::MPS; kwargs...)
+function tdvp_sweep(
+  direction::Base.Ordering, solver, PH, time_step::Number, psi::MPS; kwargs...
+)
   PH = copy(PH)
   psi = copy(psi)
   if length(psi) == 1
@@ -407,5 +409,7 @@ function tdvp_site_update!(
   mindim,
   maxtruncerr,
 ) where {nsite,reverse_step}
-  return error("`tdvp` with `nsite=$nsite` and `reverse_step=$reverse_step` not implemented.")
+  return error(
+    "`tdvp` with `nsite=$nsite` and `reverse_step=$reverse_step` not implemented."
+  )
 end

--- a/test/test_dmrg.jl
+++ b/test/test_dmrg.jl
@@ -3,7 +3,7 @@ using ITensorTDVP
 using Random
 using Test
 
-@testset "DMRG" begin
+@testset "DMRG" for nsite in [1, 2]
   N = 10
   cutoff = 1e-12
 
@@ -18,10 +18,9 @@ using Test
 
   H = MPO(os, s)
 
-  psi = randomMPS(s; linkdims=2)
+  psi = randomMPS(s; linkdims=20)
 
   nsweeps = 10
-  nsite = 2
   maxdim = [10, 20, 40, 100]
   sweeps = Sweeps(nsweeps) # number of sweeps is 5
   maxdim!(sweeps, 10, 20, 40, 100) # gradually increase states kept

--- a/test/test_dmrg_x.jl
+++ b/test/test_dmrg_x.jl
@@ -36,11 +36,16 @@ using Test
     nsweeps=20, reverse_step=false, normalize=true, maxdim=20, cutoff=1e-10, outputlevel=0
   )
 
-  ϕ = dmrg_x(ProjMPO(H), ψ; dmrg_x_kwargs...)
+  ϕ = dmrg_x(ProjMPO(H), ψ; nsite=2, dmrg_x_kwargs...)
 
   @test inner(ψ', H, ψ) / inner(ψ, ψ) ≈ inner(ϕ', H, ϕ) / inner(ϕ, ϕ) rtol = 1e-1
   @test inner(H, ψ, H, ψ) ≉ inner(ψ', H, ψ)^2 atol = 1e-1
   @test inner(H, ϕ, H, ϕ) ≈ inner(ϕ', H, ϕ)^2 atol = 1e-7
+
+  ϕ̃ = dmrg_x(ProjMPO(H), ψ; nsite=1, dmrg_x_kwargs...)
+
+  @test inner(ψ', H, ψ) / inner(ψ, ψ) ≈ inner(ϕ̃', H, ϕ̃) / inner(ϕ̃, ϕ̃) rtol = 1e-1
+  @test_broken inner(H, ϕ̃, H, ϕ̃) ≈ inner(ϕ̃', H, ϕ̃)^2 atol = 1e-7
 end
 
 nothing

--- a/test/test_tdvp.jl
+++ b/test/test_tdvp.jl
@@ -272,18 +272,11 @@ end
     (observer!)=TDVPObserver(),
   )
 
-  #display(En1)
-  #display(En2)
-  #display(Sz1)
-  #display(Sz2)
-  #@show norm(Sz1 - Sz2)
-  #@show norm(En1 - En2)
-
   @test norm(Sz1 - Sz2) < 1e-3
   @test norm(En1 - En2) < 1e-3
 end
 
-@testset "Imaginary Time Evolution" begin
+@testset "Imaginary Time Evolution" for reverse_step in [true, false]
   N = 10
   cutoff = 1e-12
   tau = 1.0
@@ -305,9 +298,8 @@ end
   trange = 0.0:tau:ttotal
   for (step, t) in enumerate(trange)
     nsite = (step <= 10 ? 2 : 1)
-    psi = tdvp(H, -tau, psi; cutoff, nsite, normalize=true, exponentiate_krylovdim=15)
+    psi = tdvp(H, -tau, psi; cutoff, nsite, reverse_step, normalize=true, exponentiate_krylovdim=15)
   end
-  #@show maxlinkdim(psi)
 
   @test inner(psi', H, psi) < -4.25
 end

--- a/test/test_tdvp.jl
+++ b/test/test_tdvp.jl
@@ -298,7 +298,9 @@ end
   trange = 0.0:tau:ttotal
   for (step, t) in enumerate(trange)
     nsite = (step <= 10 ? 2 : 1)
-    psi = tdvp(H, -tau, psi; cutoff, nsite, reverse_step, normalize=true, exponentiate_krylovdim=15)
+    psi = tdvp(
+      H, -tau, psi; cutoff, nsite, reverse_step, normalize=true, exponentiate_krylovdim=15
+    )
   end
 
   @test inner(psi', H, psi) < -4.25


### PR DESCRIPTION
Fixes #26.

This includes a few changes:
- Fix 1-site `tdvp` when `reverse_step=false`.
- Rename lower level `tdvp` functions to `tdvp_sweep` and `tdvp_step`.
- Clean up some of the code design in `tdvp_step` (replace `sweepnext` with just a simple Julia range).
- Introduce `tdvp_site_update!` inside `tdvp_step` to do the site update. This is dispatched on `nsite` and `reverse_step` to make separate implementations for `nsite=[1, 2]` or `reverse_step=[true, false]` to make the code logic simpler (fewer if-statement branches). This made it easier to debug the issue with `nsite=1` and `reverse_step=false` and I think makes the code more readable.