### PR TITLE
Linear solver

### DIFF
--- a/src/ITensorTDVP.jl
+++ b/src/ITensorTDVP.jl
@@ -2,6 +2,7 @@ module ITensorTDVP
 
 using ITensors
 using KrylovKit: exponentiate, eigsolve
+import KrylovKit
 using Printf
 using TimerOutputs
 using Observers
@@ -27,7 +28,12 @@ include("dmrg.jl")
 include("dmrg_x.jl")
 include("projmpo_apply.jl")
 include("contract_mpo_mps.jl")
+include("linsolve.jl")
 
-export tdvp, dmrg_x, to_vec, TimeDependentSum
+export tdvp, 
+       dmrg_x, 
+       to_vec, 
+       TimeDependentSum, 
+       linsolve
 
 end

--- a/src/ITensorTDVP.jl
+++ b/src/ITensorTDVP.jl
@@ -2,13 +2,19 @@ module ITensorTDVP
 
 using ITensors
 using KrylovKit: exponentiate, eigsolve
-import KrylovKit
+using KrylovKit: KrylovKit
 using Printf
 using TimerOutputs
 using Observers
 
 using ITensors:
-  AbstractMPS, @debug_check, @timeit_debug, check_hascommoninds, orthocenter, ProjMPS, set_nsite!
+  AbstractMPS,
+  @debug_check,
+  @timeit_debug,
+  check_hascommoninds,
+  orthocenter,
+  ProjMPS,
+  set_nsite!
 
 # Compatibility of ITensor observer and Observers
 include("update_observer.jl")
@@ -32,10 +38,6 @@ include("projmps2.jl")
 include("projmpo_mps2.jl")
 include("linsolve.jl")
 
-export tdvp, 
-       dmrg_x, 
-       to_vec, 
-       TimeDependentSum, 
-       linsolve
+export tdvp, dmrg_x, to_vec, TimeDependentSum, linsolve
 
 end

--- a/src/ITensorTDVP.jl
+++ b/src/ITensorTDVP.jl
@@ -3,6 +3,7 @@ module ITensorTDVP
 using ITensors
 using KrylovKit: exponentiate, eigsolve
 using KrylovKit: KrylovKit
+import KrylovKit: linsolve
 using Printf
 using TimerOutputs
 using Observers

--- a/src/ITensorTDVP.jl
+++ b/src/ITensorTDVP.jl
@@ -28,6 +28,8 @@ include("dmrg.jl")
 include("dmrg_x.jl")
 include("projmpo_apply.jl")
 include("contract_mpo_mps.jl")
+include("projmps2.jl")
+include("projmpo_mps2.jl")
 include("linsolve.jl")
 
 export tdvp, 

--- a/src/ITensorTDVP.jl
+++ b/src/ITensorTDVP.jl
@@ -8,7 +8,7 @@ using TimerOutputs
 using Observers
 
 using ITensors:
-  AbstractMPS, @debug_check, @timeit_debug, check_hascommoninds, orthocenter, set_nsite!
+  AbstractMPS, @debug_check, @timeit_debug, check_hascommoninds, orthocenter, ProjMPS, set_nsite!
 
 # Compatibility of ITensor observer and Observers
 include("update_observer.jl")

--- a/src/linsolve.jl
+++ b/src/linsolve.jl
@@ -7,15 +7,27 @@ Compute a solution x to the linear system:
 using starting guess x₀. Leaving a₀, a₁
 set to their default values solves the 
 system A*x = b.
+
+To adjust the balance between accuracy of solution
+and speed of the algorithm, it is recommed to first try
+adjusting the `solver_tol` keyword argument descibed below.
+
+Keyword arguments:
+  - `ishermitian::Bool=false` - should set to true if the MPO A is Hermitian
+  - `solver_krylovdim::Int=30` - max number of Krylov vectors to build on each solver iteration
+  - `solver_maxiter::Int=100` - max number outer iterations (restarts) to do in the solver step
+  - `solver_tol::Float64=1E-14` - tolerance or error goal of the solver
 """
-function linsolve(A::MPO, b::MPS, x₀::MPS, a₀::Number=0, a₁::Number=1; reverse_step=false, kwargs...)
+function linsolve(
+  A::MPO, b::MPS, x₀::MPS, a₀::Number=0, a₁::Number=1; reverse_step=false, kwargs...
+)
   function linsolve_solver(P::ProjMPO_MPS2, t, x₀; kws...)
     solver_kwargs = (;
       ishermitian=kws[:ishermitian],
       tol=kws[:solver_tol],
       krylovdim=kws[:solver_krylovdim],
       maxiter=kws[:solver_maxiter],
-      verbosity=kws[:solver_verbosity]
+      verbosity=kws[:solver_verbosity],
     )
     b = only(proj_mps(P))
     x, info = KrylovKit.linsolve(P, b, x₀, a₀, a₁; solver_kwargs...)
@@ -26,11 +38,10 @@ function linsolve(A::MPO, b::MPS, x₀::MPS, a₀::Number=0, a₁::Number=1; rev
   solver_default_kwargs = (;
     solver_tol=get(kwargs, :solver_tol, 1E-14),
     solver_krylovdim=get(kwargs, :solver_krylovdim, 30),
-    solver_maxiter=get(kwargs, :solver_maxiter, 100)
-   )
+    solver_maxiter=get(kwargs, :solver_maxiter, 100),
+  )
 
   t = Inf
   P = ProjMPO_MPS2(A, b)
   return tdvp(linsolve_solver, P, t, x₀; reverse_step, solver_default_kwargs..., kwargs...)
 end
-

--- a/src/linsolve.jl
+++ b/src/linsolve.jl
@@ -18,30 +18,31 @@ Keyword arguments:
   - `solver_maxiter::Int=100` - max number outer iterations (restarts) to do in the solver step
   - `solver_tol::Float64=1E-14` - tolerance or error goal of the solver
 """
-function linsolve(
-  A::MPO, b::MPS, x₀::MPS, a₀::Number=0, a₁::Number=1; reverse_step=false, kwargs...
-)
-  function linsolve_solver(P::ProjMPO_MPS2, t, x₀; kws...)
+function linsolve(A::MPO, b::MPS, x₀::MPS, a₀::Number=0, a₁::Number=1; kwargs...)
+  function linsolve_solver(
+    P::ProjMPO_MPS2,
+    t,
+    x₀;
+    ishermitian=false,
+    solver_tol=1E-14,
+    solver_krylovdim=30,
+    solver_maxiter=100,
+    solver_verbosity=0,
+    kwargs...,
+  )
     solver_kwargs = (;
-      ishermitian=kws[:ishermitian],
-      tol=kws[:solver_tol],
-      krylovdim=kws[:solver_krylovdim],
-      maxiter=kws[:solver_maxiter],
-      verbosity=kws[:solver_verbosity],
+      ishermitian=ishermitian,
+      tol=solver_tol,
+      krylovdim=solver_krylovdim,
+      maxiter=solver_maxiter,
+      verbosity=solver_verbosity,
     )
     b = dag(only(proj_mps(P)))
     x, info = KrylovKit.linsolve(P, b, x₀, a₀, a₁; solver_kwargs...)
     return x, nothing
   end
 
-  # Set appropriate linsolve defaults
-  solver_default_kwargs = (;
-    solver_tol=get(kwargs, :solver_tol, 1E-14),
-    solver_krylovdim=get(kwargs, :solver_krylovdim, 30),
-    solver_maxiter=get(kwargs, :solver_maxiter, 100),
-  )
-
   t = Inf
   P = ProjMPO_MPS2(A, b)
-  return tdvp(linsolve_solver, P, t, x₀; reverse_step, solver_default_kwargs..., kwargs...)
+  return tdvp(linsolve_solver, P, t, x₀; reverse_step=false, kwargs...)
 end

--- a/src/linsolve.jl
+++ b/src/linsolve.jl
@@ -1,0 +1,34 @@
+function proj(P::ProjMPS)
+  ϕ = prime(linkinds, P.M)
+  p = ITensor(1.0)
+  !isnothing(lproj(P)) && (p *= lproj(P))
+  for j in (P.lpos + 1):(P.rpos - 1)
+    p *= dag(ϕ[j])
+  end
+  !isnothing(rproj(P)) && (p *= rproj(P))
+  return dag(p)
+end
+
+# Compute a solution x to the linear system:
+#
+# (a₀ + a₁ * A)*x = b
+#
+# using starting guess x₀.
+function linsolve(A::MPO, b::MPS, x₀::MPS, a₀::Number=0, a₁::Number=1; reverse_step=false, kwargs...)
+  function linsolve_solver(P::ProjMPO_MPS, t, x₀; kws...)
+    solver_kwargs = (;
+      ishermitian=get(kws, :ishermitian, false),
+      tol=get(kws, :solver_tol, 1E-14),
+      krylovdim=get(kws, :solver_krylovdim, 30),
+      maxiter=get(kws, :solver_maxiter, 4),
+      verbosity=get(kws, :solver_verbosity, 0),
+    )
+    A = P.PH
+    b = proj(only(P.pm))
+    x, info = KrylovKit.linsolve(A, b, x₀, a₀, a₁; solver_kwargs...)
+    return x, nothing
+  end
+  t = Inf
+  P = ProjMPO_MPS(A, [b])
+  return tdvp(linsolve_solver, P, t, x₀; reverse_step, kwargs...)
+end

--- a/src/linsolve.jl
+++ b/src/linsolve.jl
@@ -29,7 +29,7 @@ function linsolve(
       maxiter=kws[:solver_maxiter],
       verbosity=kws[:solver_verbosity],
     )
-    b = only(proj_mps(P))
+    b = dag(only(proj_mps(P)))
     x, info = KrylovKit.linsolve(P, b, x₀, a₀, a₁; solver_kwargs...)
     return x, nothing
   end

--- a/src/linsolve.jl
+++ b/src/linsolve.jl
@@ -1,3 +1,4 @@
+
 function proj(P::ProjMPS)
   ϕ = prime(linkinds, P.M)
   p = ITensor(1.0)
@@ -9,11 +10,15 @@ function proj(P::ProjMPS)
   return dag(p)
 end
 
-# Compute a solution x to the linear system:
-#
-# (a₀ + a₁ * A)*x = b
-#
-# using starting guess x₀.
+"""
+Compute a solution x to the linear system:
+
+(a₀ + a₁ * A)*x = b
+
+using starting guess x₀. Leaving a₀, a₁
+set to their default values solves the 
+system A*x = b.
+"""
 function linsolve(A::MPO, b::MPS, x₀::MPS, a₀::Number=0, a₁::Number=1; reverse_step=false, kwargs...)
   function linsolve_solver(P::ProjMPO_MPS, t, x₀; kws...)
     solver_kwargs = (;
@@ -27,6 +32,9 @@ function linsolve(A::MPO, b::MPS, x₀::MPS, a₀::Number=0, a₁::Number=1; rev
     #ITensors.pause()
     A = P.PH
     b = proj(only(P.pm))
+    #@show inds(product(A,x₀))
+    #@show norm(product(A,x₀)-b)
+    #ITensors.pause()
     x, info = KrylovKit.linsolve(A, b, x₀, a₀, a₁; solver_kwargs...)
     return x, nothing
   end
@@ -34,3 +42,4 @@ function linsolve(A::MPO, b::MPS, x₀::MPS, a₀::Number=0, a₁::Number=1; rev
   P = ProjMPO_MPS(A, [b])
   return tdvp(linsolve_solver, P, t, x₀; reverse_step, kwargs...)
 end
+

--- a/src/linsolve.jl
+++ b/src/linsolve.jl
@@ -1,15 +1,4 @@
 
-function proj(P::ProjMPS)
-  ϕ = prime(linkinds, P.M)
-  p = ITensor(1.0)
-  !isnothing(lproj(P)) && (p *= lproj(P))
-  for j in (P.lpos + 1):(P.rpos - 1)
-    p *= dag(ϕ[j])
-  end
-  !isnothing(rproj(P)) && (p *= rproj(P))
-  return dag(p)
-end
-
 """
 Compute a solution x to the linear system:
 
@@ -20,26 +9,28 @@ set to their default values solves the
 system A*x = b.
 """
 function linsolve(A::MPO, b::MPS, x₀::MPS, a₀::Number=0, a₁::Number=1; reverse_step=false, kwargs...)
-  function linsolve_solver(P::ProjMPO_MPS, t, x₀; kws...)
+  function linsolve_solver(P::ProjMPO_MPS2, t, x₀; kws...)
     solver_kwargs = (;
-      ishermitian=get(kws, :ishermitian, false),
-      tol=get(kws, :solver_tol, 1E-14),
-      krylovdim=get(kws, :solver_krylovdim, 30),
-      maxiter=get(kws, :solver_maxiter, 100),
-      verbosity=get(kws, :solver_verbosity, 0),
+      ishermitian=kws[:ishermitian],
+      tol=kws[:solver_tol],
+      krylovdim=kws[:solver_krylovdim],
+      maxiter=kws[:solver_maxiter],
+      verbosity=kws[:solver_verbosity]
     )
-    #@show solver_kwargs
-    #ITensors.pause()
-    A = P.PH
-    b = proj(only(P.pm))
-    #@show inds(product(A,x₀))
-    #@show norm(product(A,x₀)-b)
-    #ITensors.pause()
-    x, info = KrylovKit.linsolve(A, b, x₀, a₀, a₁; solver_kwargs...)
+    b = only(proj_mps(P))
+    x, info = KrylovKit.linsolve(P, b, x₀, a₀, a₁; solver_kwargs...)
     return x, nothing
   end
+
+  # Set appropriate linsolve defaults
+  solver_default_kwargs = (;
+    solver_tol=get(kwargs, :solver_tol, 1E-14),
+    solver_krylovdim=get(kwargs, :solver_krylovdim, 30),
+    solver_maxiter=get(kwargs, :solver_maxiter, 100)
+   )
+
   t = Inf
-  P = ProjMPO_MPS(A, [b])
-  return tdvp(linsolve_solver, P, t, x₀; reverse_step, kwargs...)
+  P = ProjMPO_MPS2(A, b)
+  return tdvp(linsolve_solver, P, t, x₀; reverse_step, solver_default_kwargs..., kwargs...)
 end
 

--- a/src/linsolve.jl
+++ b/src/linsolve.jl
@@ -20,9 +20,11 @@ function linsolve(A::MPO, b::MPS, x₀::MPS, a₀::Number=0, a₁::Number=1; rev
       ishermitian=get(kws, :ishermitian, false),
       tol=get(kws, :solver_tol, 1E-14),
       krylovdim=get(kws, :solver_krylovdim, 30),
-      maxiter=get(kws, :solver_maxiter, 4),
+      maxiter=get(kws, :solver_maxiter, 100),
       verbosity=get(kws, :solver_verbosity, 0),
     )
+    #@show solver_kwargs
+    #ITensors.pause()
     A = P.PH
     b = proj(only(P.pm))
     x, info = KrylovKit.linsolve(A, b, x₀, a₀, a₁; solver_kwargs...)

--- a/src/projmpo_mps2.jl
+++ b/src/projmpo_mps2.jl
@@ -19,29 +19,29 @@ copy(P::ProjMPO_MPS2) = ProjMPO_MPS2(copy(P.PH), copy(P.Ms))
 nsite(P::ProjMPO_MPS2) = nsite(P.PH)
 
 function set_nsite!(P::ProjMPO_MPS2, nsite)
-  set_nsite!(P.PH,nsite)
+  set_nsite!(P.PH, nsite)
   for m in P.Ms
-    set_nsite!(m,nsite)
+    set_nsite!(m, nsite)
   end
   return P
 end
 
 function makeL!(P::ProjMPO_MPS2, psi::MPS, k::Int)
-  makeL!(P.PH,psi,k)
+  makeL!(P.PH, psi, k)
   for m in P.Ms
-    makeL!(m,psi,k)
+    makeL!(m, psi, k)
   end
   return P
 end
 
 function makeR!(P::ProjMPO_MPS2, psi::MPS, k::Int)
-  makeR!(P.PH,psi,k)
+  makeR!(P.PH, psi, k)
   for m in P.Ms
-    makeR!(m,psi,k)
+    makeR!(m, psi, k)
   end
   return P
 end
 
-contract(P::ProjMPO_MPS2, v::ITensor) = contract(P.PH,v)
+contract(P::ProjMPO_MPS2, v::ITensor) = contract(P.PH, v)
 
 proj_mps(P::ProjMPO_MPS2) = [proj_mps(m) for m in P.Ms]

--- a/src/projmpo_mps2.jl
+++ b/src/projmpo_mps2.jl
@@ -1,0 +1,47 @@
+import ITensors: AbstractProjMPO, makeL!, makeR!, set_nsite!, contract, nsite
+import Base: copy
+
+mutable struct ProjMPO_MPS2 <: AbstractProjMPO
+  PH::ProjMPO
+  Ms::Vector{ProjMPS2}
+end
+
+function ProjMPO_MPS2(H::MPO, M::MPS)
+  return ProjMPO_MPS2(ProjMPO(H), [ProjMPS2(M)])
+end
+
+function ProjMPO_MPS2(H::MPO, Mv::Vector{MPS})
+  return ProjMPO_MPS2(ProjMPO(H), [ProjMPS2(m) for m in Mv])
+end
+
+copy(P::ProjMPO_MPS2) = ProjMPO_MPS2(copy(P.PH), copy(P.Ms))
+
+nsite(P::ProjMPO_MPS2) = nsite(P.PH)
+
+function set_nsite!(P::ProjMPO_MPS2, nsite)
+  set_nsite!(P.PH,nsite)
+  for m in P.Ms
+    set_nsite!(m,nsite)
+  end
+  return P
+end
+
+function makeL!(P::ProjMPO_MPS2, psi::MPS, k::Int)
+  makeL!(P.PH,psi,k)
+  for m in P.Ms
+    makeL!(m,psi,k)
+  end
+  return P
+end
+
+function makeR!(P::ProjMPO_MPS2, psi::MPS, k::Int)
+  makeR!(P.PH,psi,k)
+  for m in P.Ms
+    makeR!(m,psi,k)
+  end
+  return P
+end
+
+contract(P::ProjMPO_MPS2, v::ITensor) = contract(P.PH,v)
+
+proj_mps(P::ProjMPO_MPS2) = [proj_mps(m) for m in P.Ms]

--- a/src/projmps2.jl
+++ b/src/projmps2.jl
@@ -105,7 +105,7 @@ end
 
 function proj_mps(P::ProjMPS2)
   itensor_map = Union{ITensor,OneITensor}[lproj(P)]
-  append!(itensor_map, [prime(t, "Link") for t in P.M[site_range(P)]])
+  append!(itensor_map, [dag(prime(t, "Link")) for t in P.M[site_range(P)]])
   push!(itensor_map, rproj(P))
 
   # Reverse the contraction order of the map if
@@ -118,6 +118,7 @@ function proj_mps(P::ProjMPS2)
   # Apply the map
   m = ITensor(1.0)
   for it in itensor_map
+    #@show inds(it)
     m *= it
   end
   return m

--- a/src/projmps2.jl
+++ b/src/projmps2.jl
@@ -1,4 +1,5 @@
-import ITensors: AbstractProjMPO, makeL!, makeR!, set_nsite!, contract, OneITensor, site_range
+import ITensors:
+  AbstractProjMPO, makeL!, makeR!, set_nsite!, contract, OneITensor, site_range
 import Base: copy
 
 """
@@ -49,7 +50,7 @@ function makeL!(P::ProjMPS2, psi::MPS, k::Int)
   ll = max(ll, 0)
   L = lproj(P)
   while ll < k
-    L = L * psi[ll + 1] * dag(prime(P.M[ll + 1],"Link"))
+    L = L * psi[ll + 1] * dag(prime(P.M[ll + 1], "Link"))
     P.LR[ll + 1] = L
     ll += 1
   end
@@ -74,7 +75,7 @@ function makeR!(P::ProjMPS2, psi::MPS, k::Int)
   rl = min(rl, N + 1)
   R = rproj(P)
   while rl > k
-    R = R * psi[rl - 1] * dag(prime(P.M[rl - 1],"Link"))
+    R = R * psi[rl - 1] * dag(prime(P.M[rl - 1], "Link"))
     P.LR[rl - 1] = R
     rl -= 1
   end
@@ -84,7 +85,7 @@ end
 
 function contract(P::ProjMPS2, v::ITensor)
   itensor_map = Union{ITensor,OneITensor}[lproj(P)]
-  append!(itensor_map, [prime(t,"Link") for t in P.M[site_range(P)]])
+  append!(itensor_map, [prime(t, "Link") for t in P.M[site_range(P)]])
   push!(itensor_map, rproj(P))
 
   # Reverse the contraction order of the map if
@@ -104,7 +105,7 @@ end
 
 function proj_mps(P::ProjMPS2)
   itensor_map = Union{ITensor,OneITensor}[lproj(P)]
-  append!(itensor_map, [prime(t,"Link") for t in P.M[site_range(P)]])
+  append!(itensor_map, [prime(t, "Link") for t in P.M[site_range(P)]])
   push!(itensor_map, rproj(P))
 
   # Reverse the contraction order of the map if
@@ -115,7 +116,7 @@ function proj_mps(P::ProjMPS2)
   end
 
   # Apply the map
-  m = ITensor(1.)
+  m = ITensor(1.0)
   for it in itensor_map
     m *= it
   end

--- a/src/projmps2.jl
+++ b/src/projmps2.jl
@@ -1,0 +1,123 @@
+import ITensors: AbstractProjMPO, makeL!, makeR!, set_nsite!, contract, OneITensor, site_range
+import Base: copy
+
+"""
+Holds the following data where psi
+is the MPS being optimized and M is the 
+MPS held constant by the ProjMPS.
+```
+     o--o--o--o--o--o--o--o--o--o--o <M|
+     |  |  |  |  |  |  |  |  |  |  |
+     *--*--*-      -*--*--*--*--*--* |psi>
+```
+"""
+mutable struct ProjMPS2 <: AbstractProjMPO
+  lpos::Int
+  rpos::Int
+  nsite::Int
+  M::MPS
+  LR::Vector{ITensor}
+end
+
+function ProjMPS2(M::MPS)
+  return ProjMPS2(0, length(M) + 1, 2, M, Vector{ITensor}(undef, length(M)))
+end
+
+Base.length(P::ProjMPS2) = length(P.M)
+
+function copy(P::ProjMPS2)
+  return ProjMPS2(P.lpos, P.rpos, P.nsite, copy(P.M), copy(P.LR))
+end
+
+function set_nsite!(P::ProjMPS2, nsite)
+  P.nsite = nsite
+  return P
+end
+
+function makeL!(P::ProjMPS2, psi::MPS, k::Int)
+  # Save the last `L` that is made to help with caching
+  # for DiskProjMPO
+  ll = P.lpos
+  if ll ≥ k
+    # Special case when nothing has to be done.
+    # Still need to change the position if lproj is
+    # being moved backward.
+    P.lpos = k
+    return nothing
+  end
+  # Make sure ll is at least 0 for the generic logic below
+  ll = max(ll, 0)
+  L = lproj(P)
+  while ll < k
+    L = L * psi[ll + 1] * dag(prime(P.M[ll + 1],"Link"))
+    P.LR[ll + 1] = L
+    ll += 1
+  end
+  # Needed when moving lproj backward.
+  P.lpos = k
+  return P
+end
+
+function makeR!(P::ProjMPS2, psi::MPS, k::Int)
+  # Save the last `R` that is made to help with caching
+  # for DiskProjMPO
+  rl = P.rpos
+  if rl ≤ k
+    # Special case when nothing has to be done.
+    # Still need to change the position if rproj is
+    # being moved backward.
+    P.rpos = k
+    return nothing
+  end
+  N = length(P.M)
+  # Make sure rl is no bigger than `N + 1` for the generic logic below
+  rl = min(rl, N + 1)
+  R = rproj(P)
+  while rl > k
+    R = R * psi[rl - 1] * dag(prime(P.M[rl - 1],"Link"))
+    P.LR[rl - 1] = R
+    rl -= 1
+  end
+  P.rpos = k
+  return P
+end
+
+function contract(P::ProjMPS2, v::ITensor)
+  itensor_map = Union{ITensor,OneITensor}[lproj(P)]
+  append!(itensor_map, [prime(t,"Link") for t in P.M[site_range(P)]])
+  push!(itensor_map, rproj(P))
+
+  # Reverse the contraction order of the map if
+  # the first tensor is a scalar (for example we
+  # are at the left edge of the system)
+  if dim(first(itensor_map)) == 1
+    reverse!(itensor_map)
+  end
+
+  # Apply the map
+  Mv = v
+  for it in itensor_map
+    Mv *= it
+  end
+  return Mv
+end
+
+function proj_mps(P::ProjMPS2)
+  itensor_map = Union{ITensor,OneITensor}[lproj(P)]
+  append!(itensor_map, [prime(t,"Link") for t in P.M[site_range(P)]])
+  push!(itensor_map, rproj(P))
+
+  # Reverse the contraction order of the map if
+  # the first tensor is a scalar (for example we
+  # are at the left edge of the system)
+  if dim(first(itensor_map)) == 1
+    reverse!(itensor_map)
+  end
+
+  # Apply the map
+  m = ITensor(1.)
+  for it in itensor_map
+    m *= it
+  end
+  return m
+end

--- a/src/tdvp_generic.jl
+++ b/src/tdvp_generic.jl
@@ -1,7 +1,9 @@
 function _tdvp_compute_nsweeps(t; kwargs...)
   time_step::Number = get(kwargs, :time_step, t)
   nsweeps::Union{Int,Nothing} = get(kwargs, :nsweeps, nothing)
-  if !isnothing(nsweeps) && time_step != t
+  if isinf(t) && isnothing(nsweeps)
+    nsweeps = 1
+  elseif !isnothing(nsweeps) && time_step != t
     error("Cannot specify both time_step and nsweeps in tdvp")
   elseif isfinite(time_step) && abs(time_step) > 0.0 && isnothing(nsweeps)
     nsweeps = convert(Int, ceil(abs(t / time_step)))

--- a/src/tdvp_step.jl
+++ b/src/tdvp_step.jl
@@ -95,12 +95,12 @@ function tdvp_sweep(
       maxdim,
       mindim,
       maxtruncerr,
-      solver_which_eigenvalue = get(kwargs, :solver_which_eigenvalue, :SR),
+      solver_which_eigenvalue=get(kwargs, :solver_which_eigenvalue, :SR),
       solver_tol=get(kwargs, :solver_tol, 1E-14),
       solver_krylovdim=get(kwargs, :solver_krylovdim, 3),
       solver_maxiter=get(kwargs, :solver_maxiter, 1),
       solver_verbosity=get(kwargs, :solver_verbosity, 0),
-      ishermitian=get(kwargs, :ishermitian, false)
+      ishermitian=get(kwargs, :ishermitian, false),
     )
     if outputlevel >= 2
       if nsite == 1
@@ -157,12 +157,12 @@ function tdvp_site_update!(
   maxdim,
   mindim,
   maxtruncerr,
-    solver_which_eigenvalue,
-    solver_tol,
-    solver_krylovdim,
-    solver_maxiter,
-    solver_verbosity,
-    ishermitian
+  solver_which_eigenvalue,
+  solver_tol,
+  solver_krylovdim,
+  solver_maxiter,
+  solver_verbosity,
+  ishermitian,
 )
   return tdvp_site_update!(
     Val(nsite),
@@ -188,7 +188,7 @@ function tdvp_site_update!(
     solver_krylovdim,
     solver_maxiter,
     solver_verbosity,
-    ishermitian
+    ishermitian,
   )
 end
 
@@ -216,7 +216,7 @@ function tdvp_site_update!(
   solver_krylovdim,
   solver_maxiter,
   solver_verbosity,
-  ishermitian
+  ishermitian,
 )
   N = length(psi)
   nsite = 1
@@ -224,13 +224,19 @@ function tdvp_site_update!(
   set_nsite!(PH, nsite)
   position!(PH, psi, b)
   phi1 = psi[b]
-  phi1, info = solver(PH, time_step, phi1; current_time, outputlevel,
+  phi1, info = solver(
+    PH,
+    time_step,
+    phi1;
+    current_time,
+    outputlevel,
     solver_which_eigenvalue,
     solver_tol,
     solver_krylovdim,
     solver_maxiter,
     solver_verbosity,
-    ishermitian)
+    ishermitian,
+  )
   current_time += time_step
   normalize && (phi1 /= norm(phi1))
   spec = nothing
@@ -267,7 +273,7 @@ function tdvp_site_update!(
   solver_krylovdim,
   solver_maxiter,
   solver_verbosity,
-  ishermitian
+  ishermitian,
 )
   N = length(psi)
   nsite = 1
@@ -275,13 +281,19 @@ function tdvp_site_update!(
   set_nsite!(PH, nsite)
   position!(PH, psi, b)
   phi1 = psi[b]
-  phi1, info = solver(PH, time_step, phi1; current_time, outputlevel,
+  phi1, info = solver(
+    PH,
+    time_step,
+    phi1;
+    current_time,
+    outputlevel,
     solver_which_eigenvalue,
     solver_tol,
     solver_krylovdim,
     solver_maxiter,
     solver_verbosity,
-    ishermitian)
+    ishermitian,
+  )
   current_time += time_step
   normalize && (phi1 /= norm(phi1))
   spec = nothing
@@ -301,13 +313,19 @@ function tdvp_site_update!(
     end
     set_nsite!(PH, nsite - 1)
     position!(PH, psi, b1)
-    phi0, info = solver(PH, -time_step, phi0; current_time, outputlevel,
+    phi0, info = solver(
+      PH,
+      -time_step,
+      phi0;
+      current_time,
+      outputlevel,
       solver_which_eigenvalue,
       solver_tol,
       solver_krylovdim,
       solver_maxiter,
       solver_verbosity,
-      ishermitian)
+      ishermitian,
+    )
     current_time -= time_step
     normalize && (phi0 ./= norm(phi0))
     psi[b + Δ] = phi0 * psi[b + Δ]
@@ -345,7 +363,7 @@ function tdvp_site_update!(
   solver_krylovdim,
   solver_maxiter,
   solver_verbosity,
-  ishermitian
+  ishermitian,
 )
   N = length(psi)
   nsite = 2
@@ -353,13 +371,19 @@ function tdvp_site_update!(
   set_nsite!(PH, nsite)
   position!(PH, psi, b)
   phi1 = psi[b] * psi[b + 1]
-  phi1, info = solver(PH, time_step, phi1; current_time, outputlevel,
+  phi1, info = solver(
+    PH,
+    time_step,
+    phi1;
+    current_time,
+    outputlevel,
     solver_which_eigenvalue,
     solver_tol,
     solver_krylovdim,
     solver_maxiter,
     solver_verbosity,
-    ishermitian)
+    ishermitian,
+  )
   current_time += time_step
   normalize && (phi1 /= norm(phi1))
   spec = nothing
@@ -409,7 +433,7 @@ function tdvp_site_update!(
   solver_krylovdim,
   solver_maxiter,
   solver_verbosity,
-  ishermitian
+  ishermitian,
 )
   N = length(psi)
   nsite = 2
@@ -417,13 +441,19 @@ function tdvp_site_update!(
   set_nsite!(PH, nsite)
   position!(PH, psi, b)
   phi1 = psi[b] * psi[b + 1]
-  phi1, info = solver(PH, time_step, phi1; current_time, outputlevel,
+  phi1, info = solver(
+    PH,
+    time_step,
+    phi1;
+    current_time,
+    outputlevel,
     solver_which_eigenvalue,
     solver_tol,
     solver_krylovdim,
     solver_maxiter,
     solver_verbosity,
-    ishermitian)
+    ishermitian,
+  )
   current_time += time_step
   normalize && (phi1 /= norm(phi1))
   spec = nothing
@@ -453,13 +483,19 @@ function tdvp_site_update!(
     phi0 = psi[b1]
     set_nsite!(PH, nsite - 1)
     position!(PH, psi, b1)
-    phi0, info = solver(PH, -time_step, phi0; current_time, outputlevel,
+    phi0, info = solver(
+      PH,
+      -time_step,
+      phi0;
+      current_time,
+      outputlevel,
       solver_which_eigenvalue,
       solver_tol,
       solver_krylovdim,
       solver_maxiter,
       solver_verbosity,
-      ishermitian)
+      ishermitian,
+    )
     current_time -= time_step
     normalize && (phi0 ./= norm(phi0))
     psi[b1] = phi0
@@ -487,11 +523,12 @@ function tdvp_site_update!(
   maxdim,
   mindim,
   maxtruncerr,
-    solver_which_eigenvalue,
-    solver_tol,
-    solver_krylovdim,
-    solver_maxiter,
-    solver_verbosity, ishermitian
+  solver_which_eigenvalue,
+  solver_tol,
+  solver_krylovdim,
+  solver_maxiter,
+  solver_verbosity,
+  ishermitian,
 ) where {nsite,reverse_step}
   return error(
     "`tdvp` with `nsite=$nsite` and `reverse_step=$reverse_step` not implemented."

--- a/src/tdvp_step.jl
+++ b/src/tdvp_step.jl
@@ -95,12 +95,6 @@ function tdvp_sweep(
       maxdim,
       mindim,
       maxtruncerr,
-      solver_which_eigenvalue=get(kwargs, :solver_which_eigenvalue, :SR),
-      solver_tol=get(kwargs, :solver_tol, 1E-14),
-      solver_krylovdim=get(kwargs, :solver_krylovdim, 3),
-      solver_maxiter=get(kwargs, :solver_maxiter, 1),
-      solver_verbosity=get(kwargs, :solver_verbosity, 0),
-      ishermitian=get(kwargs, :ishermitian, false),
     )
     if outputlevel >= 2
       if nsite == 1
@@ -157,12 +151,6 @@ function tdvp_site_update!(
   maxdim,
   mindim,
   maxtruncerr,
-  solver_which_eigenvalue,
-  solver_tol,
-  solver_krylovdim,
-  solver_maxiter,
-  solver_verbosity,
-  ishermitian,
 )
   return tdvp_site_update!(
     Val(nsite),
@@ -183,12 +171,6 @@ function tdvp_site_update!(
     maxdim,
     mindim,
     maxtruncerr,
-    solver_which_eigenvalue,
-    solver_tol,
-    solver_krylovdim,
-    solver_maxiter,
-    solver_verbosity,
-    ishermitian,
   )
 end
 
@@ -211,12 +193,6 @@ function tdvp_site_update!(
   maxdim,
   mindim,
   maxtruncerr,
-  solver_which_eigenvalue,
-  solver_tol,
-  solver_krylovdim,
-  solver_maxiter,
-  solver_verbosity,
-  ishermitian,
 )
   N = length(psi)
   nsite = 1
@@ -224,19 +200,7 @@ function tdvp_site_update!(
   set_nsite!(PH, nsite)
   position!(PH, psi, b)
   phi1 = psi[b]
-  phi1, info = solver(
-    PH,
-    time_step,
-    phi1;
-    current_time,
-    outputlevel,
-    solver_which_eigenvalue,
-    solver_tol,
-    solver_krylovdim,
-    solver_maxiter,
-    solver_verbosity,
-    ishermitian,
-  )
+  phi1, info = solver(PH, time_step, phi1; current_time, outputlevel)
   current_time += time_step
   normalize && (phi1 /= norm(phi1))
   spec = nothing
@@ -268,12 +232,6 @@ function tdvp_site_update!(
   maxdim,
   mindim,
   maxtruncerr,
-  solver_which_eigenvalue,
-  solver_tol,
-  solver_krylovdim,
-  solver_maxiter,
-  solver_verbosity,
-  ishermitian,
 )
   N = length(psi)
   nsite = 1
@@ -281,19 +239,7 @@ function tdvp_site_update!(
   set_nsite!(PH, nsite)
   position!(PH, psi, b)
   phi1 = psi[b]
-  phi1, info = solver(
-    PH,
-    time_step,
-    phi1;
-    current_time,
-    outputlevel,
-    solver_which_eigenvalue,
-    solver_tol,
-    solver_krylovdim,
-    solver_maxiter,
-    solver_verbosity,
-    ishermitian,
-  )
+  phi1, info = solver(PH, time_step, phi1; current_time, outputlevel)
   current_time += time_step
   normalize && (phi1 /= norm(phi1))
   spec = nothing
@@ -313,19 +259,7 @@ function tdvp_site_update!(
     end
     set_nsite!(PH, nsite - 1)
     position!(PH, psi, b1)
-    phi0, info = solver(
-      PH,
-      -time_step,
-      phi0;
-      current_time,
-      outputlevel,
-      solver_which_eigenvalue,
-      solver_tol,
-      solver_krylovdim,
-      solver_maxiter,
-      solver_verbosity,
-      ishermitian,
-    )
+    phi0, info = solver(PH, -time_step, phi0; current_time, outputlevel)
     current_time -= time_step
     normalize && (phi0 ./= norm(phi0))
     psi[b + Δ] = phi0 * psi[b + Δ]
@@ -358,12 +292,6 @@ function tdvp_site_update!(
   maxdim,
   mindim,
   maxtruncerr,
-  solver_which_eigenvalue,
-  solver_tol,
-  solver_krylovdim,
-  solver_maxiter,
-  solver_verbosity,
-  ishermitian,
 )
   N = length(psi)
   nsite = 2
@@ -371,19 +299,7 @@ function tdvp_site_update!(
   set_nsite!(PH, nsite)
   position!(PH, psi, b)
   phi1 = psi[b] * psi[b + 1]
-  phi1, info = solver(
-    PH,
-    time_step,
-    phi1;
-    current_time,
-    outputlevel,
-    solver_which_eigenvalue,
-    solver_tol,
-    solver_krylovdim,
-    solver_maxiter,
-    solver_verbosity,
-    ishermitian,
-  )
+  phi1, info = solver(PH, time_step, phi1; current_time, outputlevel)
   current_time += time_step
   normalize && (phi1 /= norm(phi1))
   spec = nothing
@@ -428,12 +344,6 @@ function tdvp_site_update!(
   maxdim,
   mindim,
   maxtruncerr,
-  solver_which_eigenvalue,
-  solver_tol,
-  solver_krylovdim,
-  solver_maxiter,
-  solver_verbosity,
-  ishermitian,
 )
   N = length(psi)
   nsite = 2
@@ -441,19 +351,7 @@ function tdvp_site_update!(
   set_nsite!(PH, nsite)
   position!(PH, psi, b)
   phi1 = psi[b] * psi[b + 1]
-  phi1, info = solver(
-    PH,
-    time_step,
-    phi1;
-    current_time,
-    outputlevel,
-    solver_which_eigenvalue,
-    solver_tol,
-    solver_krylovdim,
-    solver_maxiter,
-    solver_verbosity,
-    ishermitian,
-  )
+  phi1, info = solver(PH, time_step, phi1; current_time, outputlevel)
   current_time += time_step
   normalize && (phi1 /= norm(phi1))
   spec = nothing
@@ -483,19 +381,7 @@ function tdvp_site_update!(
     phi0 = psi[b1]
     set_nsite!(PH, nsite - 1)
     position!(PH, psi, b1)
-    phi0, info = solver(
-      PH,
-      -time_step,
-      phi0;
-      current_time,
-      outputlevel,
-      solver_which_eigenvalue,
-      solver_tol,
-      solver_krylovdim,
-      solver_maxiter,
-      solver_verbosity,
-      ishermitian,
-    )
+    phi0, info = solver(PH, -time_step, phi0; current_time, outputlevel)
     current_time -= time_step
     normalize && (phi0 ./= norm(phi0))
     psi[b1] = phi0
@@ -523,12 +409,6 @@ function tdvp_site_update!(
   maxdim,
   mindim,
   maxtruncerr,
-  solver_which_eigenvalue,
-  solver_tol,
-  solver_krylovdim,
-  solver_maxiter,
-  solver_verbosity,
-  ishermitian,
 ) where {nsite,reverse_step}
   return error(
     "`tdvp` with `nsite=$nsite` and `reverse_step=$reverse_step` not implemented."

--- a/src/tdvp_step.jl
+++ b/src/tdvp_step.jl
@@ -58,6 +58,7 @@ function tdvp_sweep(
   mindim::Integer = get(kwargs, :mindim, 1)
   cutoff::Real = get(kwargs, :cutoff, 1E-16)
   noise::Real = get(kwargs, :noise, 0.0)
+
   N = length(psi)
   set_nsite!(PH, nsite)
   if isforward(direction)
@@ -94,6 +95,12 @@ function tdvp_sweep(
       maxdim,
       mindim,
       maxtruncerr,
+      solver_which_eigenvalue = get(kwargs, :solver_which_eigenvalue, :SR),
+      solver_tol=get(kwargs, :solver_tol, 1E-14),
+      solver_krylovdim=get(kwargs, :solver_krylovdim, 3),
+      solver_maxiter=get(kwargs, :solver_maxiter, 1),
+      solver_verbosity=get(kwargs, :solver_verbosity, 0),
+      ishermitian=get(kwargs, :ishermitian, false)
     )
     if outputlevel >= 2
       if nsite == 1
@@ -150,6 +157,12 @@ function tdvp_site_update!(
   maxdim,
   mindim,
   maxtruncerr,
+    solver_which_eigenvalue,
+    solver_tol,
+    solver_krylovdim,
+    solver_maxiter,
+    solver_verbosity,
+    ishermitian
 )
   return tdvp_site_update!(
     Val(nsite),
@@ -170,6 +183,12 @@ function tdvp_site_update!(
     maxdim,
     mindim,
     maxtruncerr,
+    solver_which_eigenvalue,
+    solver_tol,
+    solver_krylovdim,
+    solver_maxiter,
+    solver_verbosity,
+    ishermitian
   )
 end
 
@@ -192,6 +211,12 @@ function tdvp_site_update!(
   maxdim,
   mindim,
   maxtruncerr,
+  solver_which_eigenvalue,
+  solver_tol,
+  solver_krylovdim,
+  solver_maxiter,
+  solver_verbosity,
+  ishermitian
 )
   N = length(psi)
   nsite = 1
@@ -199,7 +224,13 @@ function tdvp_site_update!(
   set_nsite!(PH, nsite)
   position!(PH, psi, b)
   phi1 = psi[b]
-  phi1, info = solver(PH, time_step, phi1; current_time, outputlevel)
+  phi1, info = solver(PH, time_step, phi1; current_time, outputlevel,
+    solver_which_eigenvalue,
+    solver_tol,
+    solver_krylovdim,
+    solver_maxiter,
+    solver_verbosity,
+    ishermitian)
   current_time += time_step
   normalize && (phi1 /= norm(phi1))
   spec = nothing
@@ -231,6 +262,12 @@ function tdvp_site_update!(
   maxdim,
   mindim,
   maxtruncerr,
+  solver_which_eigenvalue,
+  solver_tol,
+  solver_krylovdim,
+  solver_maxiter,
+  solver_verbosity,
+  ishermitian
 )
   N = length(psi)
   nsite = 1
@@ -238,7 +275,13 @@ function tdvp_site_update!(
   set_nsite!(PH, nsite)
   position!(PH, psi, b)
   phi1 = psi[b]
-  phi1, info = solver(PH, time_step, phi1; current_time, outputlevel)
+  phi1, info = solver(PH, time_step, phi1; current_time, outputlevel,
+    solver_which_eigenvalue,
+    solver_tol,
+    solver_krylovdim,
+    solver_maxiter,
+    solver_verbosity,
+    ishermitian)
   current_time += time_step
   normalize && (phi1 /= norm(phi1))
   spec = nothing
@@ -258,7 +301,13 @@ function tdvp_site_update!(
     end
     set_nsite!(PH, nsite - 1)
     position!(PH, psi, b1)
-    phi0, info = solver(PH, -time_step, phi0; current_time, outputlevel)
+    phi0, info = solver(PH, -time_step, phi0; current_time, outputlevel,
+      solver_which_eigenvalue,
+      solver_tol,
+      solver_krylovdim,
+      solver_maxiter,
+      solver_verbosity,
+      ishermitian)
     current_time -= time_step
     normalize && (phi0 ./= norm(phi0))
     psi[b + Δ] = phi0 * psi[b + Δ]
@@ -291,6 +340,12 @@ function tdvp_site_update!(
   maxdim,
   mindim,
   maxtruncerr,
+  solver_which_eigenvalue,
+  solver_tol,
+  solver_krylovdim,
+  solver_maxiter,
+  solver_verbosity,
+  ishermitian
 )
   N = length(psi)
   nsite = 2
@@ -298,7 +353,13 @@ function tdvp_site_update!(
   set_nsite!(PH, nsite)
   position!(PH, psi, b)
   phi1 = psi[b] * psi[b + 1]
-  phi1, info = solver(PH, time_step, phi1; current_time, outputlevel)
+  phi1, info = solver(PH, time_step, phi1; current_time, outputlevel,
+    solver_which_eigenvalue,
+    solver_tol,
+    solver_krylovdim,
+    solver_maxiter,
+    solver_verbosity,
+    ishermitian)
   current_time += time_step
   normalize && (phi1 /= norm(phi1))
   spec = nothing
@@ -343,6 +404,12 @@ function tdvp_site_update!(
   maxdim,
   mindim,
   maxtruncerr,
+  solver_which_eigenvalue,
+  solver_tol,
+  solver_krylovdim,
+  solver_maxiter,
+  solver_verbosity,
+  ishermitian
 )
   N = length(psi)
   nsite = 2
@@ -350,7 +417,13 @@ function tdvp_site_update!(
   set_nsite!(PH, nsite)
   position!(PH, psi, b)
   phi1 = psi[b] * psi[b + 1]
-  phi1, info = solver(PH, time_step, phi1; current_time, outputlevel)
+  phi1, info = solver(PH, time_step, phi1; current_time, outputlevel,
+    solver_which_eigenvalue,
+    solver_tol,
+    solver_krylovdim,
+    solver_maxiter,
+    solver_verbosity,
+    ishermitian)
   current_time += time_step
   normalize && (phi1 /= norm(phi1))
   spec = nothing
@@ -380,7 +453,13 @@ function tdvp_site_update!(
     phi0 = psi[b1]
     set_nsite!(PH, nsite - 1)
     position!(PH, psi, b1)
-    phi0, info = solver(PH, -time_step, phi0; current_time, outputlevel)
+    phi0, info = solver(PH, -time_step, phi0; current_time, outputlevel,
+      solver_which_eigenvalue,
+      solver_tol,
+      solver_krylovdim,
+      solver_maxiter,
+      solver_verbosity,
+      ishermitian)
     current_time -= time_step
     normalize && (phi0 ./= norm(phi0))
     psi[b1] = phi0
@@ -408,6 +487,11 @@ function tdvp_site_update!(
   maxdim,
   mindim,
   maxtruncerr,
+    solver_which_eigenvalue,
+    solver_tol,
+    solver_krylovdim,
+    solver_maxiter,
+    solver_verbosity, ishermitian
 ) where {nsite,reverse_step}
   return error(
     "`tdvp` with `nsite=$nsite` and `reverse_step=$reverse_step` not implemented."

--- a/test/test_contract_mpo.jl
+++ b/test/test_contract_mpo.jl
@@ -37,18 +37,18 @@ using Test
 
   # Test with nsweeps=2
   Hpsi = apply(H, psi; alg="fit", nsweeps=2)
-  @test inner(psi, Hpsi) ≈ inner(psit, H, psi) atol = 1E-5
+  @test inner(psit, Hpsi) ≈ inner(psit, H, psi) atol = 1E-5
 
   # Test with less good initial guess MPS not equal to psi
   psi_guess = copy(psi)
   truncate!(psi_guess; maxdim=2)
   Hpsi = apply(H, psi; alg="fit", nsweeps=4, init_mps=psi_guess)
-  @test inner(psi, Hpsi) ≈ inner(psit, H, psi) atol = 1E-5
+  @test inner(psit, Hpsi) ≈ inner(psit, H, psi) atol = 1E-5
 
   # Test with nsite=1
   Hpsi_guess = apply(H, psi; alg="naive", cutoff=1E-4)
   Hpsi = apply(H, psi; alg="fit", init_mps=Hpsi_guess, nsite=1, nsweeps=2)
-  @test inner(psi, Hpsi) ≈ inner(psit, H, psi) atol = 1E-4
+  @test inner(psit, Hpsi) ≈ inner(psit, H, psi) atol = 1E-4
 end
 
 nothing

--- a/test/test_linsolve.jl
+++ b/test/test_linsolve.jl
@@ -8,7 +8,7 @@ using Test
   nsweeps = 2
 
   N = 8
-  s = siteinds("S=1/2", N)
+  s = siteinds("S=1/2", N; conserve_qns=true)
 
   os = OpSum()
   for j in 1:(N - 1)
@@ -18,15 +18,29 @@ using Test
   end
   H = MPO(os, s)
 
+  state = [isodd(n) ? "Up" : "Dn" for n=1:N]
+
   # Correct x is x_c
-  x_c = randomMPS(s; linkdims=4)
+  x_c = randomMPS(s,state; linkdims=4)
   # Compute b
   b = apply(H, x_c; cutoff)
 
-  x0 = randomMPS(s; linkdims=10)
+  x0 = randomMPS(s,state; linkdims=10)
   x = linsolve(H, b, x0; cutoff, maxdim, nsweeps, ishermitian=true, solver_tol=1E-6)
 
-  #@show linkdims(x)
+  @show norm(x - x_c)
+  @test norm(x - x_c) < 1E-4
+
+
+  #
+  # Test complex case
+  #
+  x_c = randomMPS(s,state; linkdims=4) + 0.1im * randomMPS(s,state; linkdims=2)
+  b = apply(H, x_c; cutoff)
+
+  x0 = randomMPS(s,state; linkdims=10)
+  x = linsolve(H, b, x0; cutoff, maxdim, nsweeps, ishermitian=true, solver_tol=1E-6)
+
   @show norm(x - x_c)
   @test norm(x - x_c) < 1E-4
 end

--- a/test/test_linsolve.jl
+++ b/test/test_linsolve.jl
@@ -18,27 +18,26 @@ using Test
   end
   H = MPO(os, s)
 
-  state = [isodd(n) ? "Up" : "Dn" for n=1:N]
+  state = [isodd(n) ? "Up" : "Dn" for n in 1:N]
 
   # Correct x is x_c
-  x_c = randomMPS(s,state; linkdims=4)
+  x_c = randomMPS(s, state; linkdims=4)
   # Compute b
   b = apply(H, x_c; cutoff)
 
-  x0 = randomMPS(s,state; linkdims=10)
+  x0 = randomMPS(s, state; linkdims=10)
   x = linsolve(H, b, x0; cutoff, maxdim, nsweeps, ishermitian=true, solver_tol=1E-6)
 
   @show norm(x - x_c)
   @test norm(x - x_c) < 1E-4
 
-
   #
   # Test complex case
   #
-  x_c = randomMPS(s,state; linkdims=4) + 0.1im * randomMPS(s,state; linkdims=2)
+  x_c = randomMPS(s, state; linkdims=4) + 0.1im * randomMPS(s, state; linkdims=2)
   b = apply(H, x_c; cutoff)
 
-  x0 = randomMPS(s,state; linkdims=10)
+  x0 = randomMPS(s, state; linkdims=10)
   x = linsolve(H, b, x0; cutoff, maxdim, nsweeps, ishermitian=true, solver_tol=1E-6)
 
   @show norm(x - x_c)

--- a/test/test_linsolve.jl
+++ b/test/test_linsolve.jl
@@ -1,47 +1,50 @@
 using ITensors
 using ITensorTDVP
 using Test
+using Random
 
 @testset "Linsolve" begin
-  cutoff = 1E-11
-  maxdim = 8
-  nsweeps = 2
+  @testset "Linsolve Basics" begin
+    cutoff = 1E-11
+    maxdim = 8
+    nsweeps = 2
 
-  N = 8
-  s = siteinds("S=1/2", N; conserve_qns=true)
+    N = 8
+    s = siteinds("S=1/2", N; conserve_qns=true)
 
-  os = OpSum()
-  for j in 1:(N - 1)
-    os += 0.5, "S+", j, "S-", j + 1
-    os += 0.5, "S-", j, "S+", j + 1
-    os += "Sz", j, "Sz", j + 1
+    os = OpSum()
+    for j in 1:(N - 1)
+      os += 0.5, "S+", j, "S-", j + 1
+      os += 0.5, "S-", j, "S+", j + 1
+      os += "Sz", j, "Sz", j + 1
+    end
+    H = MPO(os, s)
+
+    state = [isodd(n) ? "Up" : "Dn" for n in 1:N]
+
+    ## Correct x is x_c
+    #x_c = randomMPS(s, state; linkdims=4)
+    ## Compute b
+    #b = apply(H, x_c; cutoff)
+
+    #x0 = randomMPS(s, state; linkdims=10)
+    #x = linsolve(H, b, x0; cutoff, maxdim, nsweeps, ishermitian=true, solver_tol=1E-6)
+
+    #@show norm(x - x_c)
+    #@test norm(x - x_c) < 1E-4
+
+    #
+    # Test complex case
+    #
+    x_c = randomMPS(s, state; linkdims=4) + 0.1im * randomMPS(s, state; linkdims=2)
+    b = apply(H, x_c; cutoff)
+
+    x0 = randomMPS(s, state; linkdims=10)
+    x = linsolve(H, b, x0; cutoff, maxdim, nsweeps, ishermitian=true, solver_tol=1E-6)
+
+    @show norm(x - x_c)
+    @test norm(x - x_c) < 1E-4
   end
-  H = MPO(os, s)
-
-  state = [isodd(n) ? "Up" : "Dn" for n in 1:N]
-
-  # Correct x is x_c
-  x_c = randomMPS(s, state; linkdims=4)
-  # Compute b
-  b = apply(H, x_c; cutoff)
-
-  x0 = randomMPS(s, state; linkdims=10)
-  x = linsolve(H, b, x0; cutoff, maxdim, nsweeps, ishermitian=true, solver_tol=1E-6)
-
-  @show norm(x - x_c)
-  @test norm(x - x_c) < 1E-4
-
-  #
-  # Test complex case
-  #
-  x_c = randomMPS(s, state; linkdims=4) + 0.1im * randomMPS(s, state; linkdims=2)
-  b = apply(H, x_c; cutoff)
-
-  x0 = randomMPS(s, state; linkdims=10)
-  x = linsolve(H, b, x0; cutoff, maxdim, nsweeps, ishermitian=true, solver_tol=1E-6)
-
-  @show norm(x - x_c)
-  @test norm(x - x_c) < 1E-4
 end
 
 nothing

--- a/test/test_linsolve.jl
+++ b/test/test_linsolve.jl
@@ -18,23 +18,17 @@ using Test
   end
   H = MPO(os, s)
 
-  # Correct x
+  # Correct x is x_c
   x_c = randomMPS(s; linkdims=4)
-
+  # Compute b
   b = apply(H, x_c; cutoff)
 
-  #x0 = copy(b)
-  #x0 = copy(x_c)
   x0 = randomMPS(s;linkdims=10)
-  x = linsolve(H, b, x0; cutoff, maxdim, nsweeps, ishermitian=true)
+  x = linsolve(H, b, x0; cutoff, maxdim, nsweeps, ishermitian=true, solver_tol=1E-14)
 
   @show linkdims(x)
   @show norm(apply(H, x) - b)
-  @show norm(apply(H, x_c) - b)
   @show norm(x-x_c)
-
-  #@show inner(x,x)
-  #@show inner(x_c,x)/sqrt(inner(x,x))
 
 end
 

--- a/test/test_linsolve.jl
+++ b/test/test_linsolve.jl
@@ -3,7 +3,10 @@ using ITensorTDVP
 using Test
 
 @testset "Linsolve" begin
-  cutoff = 1E-10
+  cutoff = 1E-11
+  maxdim = 8
+  nsweeps = 2
+
   N = 8
   s = siteinds("S=1/2", N)
 
@@ -20,13 +23,15 @@ using Test
 
   b = apply(H, x_c; cutoff)
 
-  #x = linsolve(H, b; cutoff, nsweeps=3, ishermitian=true, outputlevel=2)
-  x0 = copy(b)
-  x = ITensorTDVP.dmrg_linsolve(H, b, b; cutoff, nsweeps=4, ishermitian=true)
+  #x0 = copy(b)
+  #x0 = copy(x_c)
+  x0 = randomMPS(s;linkdims=10)
+  x = linsolve(H, b, x0; cutoff, maxdim, nsweeps, ishermitian=true)
 
   @show linkdims(x)
   @show norm(apply(H, x) - b)
   @show norm(apply(H, x_c) - b)
+  @show norm(x-x_c)
 
   #@show inner(x,x)
   #@show inner(x_c,x)/sqrt(inner(x,x))

--- a/test/test_linsolve.jl
+++ b/test/test_linsolve.jl
@@ -23,13 +23,12 @@ using Test
   # Compute b
   b = apply(H, x_c; cutoff)
 
-  x0 = randomMPS(s;linkdims=10)
-  x = linsolve(H, b, x0; cutoff, maxdim, nsweeps, ishermitian=true, solver_tol=1E-14)
+  x0 = randomMPS(s; linkdims=10)
+  x = linsolve(H, b, x0; cutoff, maxdim, nsweeps, ishermitian=true, solver_tol=1E-6)
 
-  @show linkdims(x)
-  @show norm(apply(H, x) - b)
-  @show norm(x-x_c)
-
+  #@show linkdims(x)
+  @show norm(x - x_c)
+  @test norm(x - x_c) < 1E-4
 end
 
 nothing

--- a/test/test_linsolve.jl
+++ b/test/test_linsolve.jl
@@ -1,0 +1,36 @@
+using ITensors
+using ITensorTDVP
+using Test
+
+@testset "Linsolve" begin
+  cutoff = 1E-10
+  N = 8
+  s = siteinds("S=1/2", N)
+
+  os = OpSum()
+  for j in 1:(N - 1)
+    os += 0.5, "S+", j, "S-", j + 1
+    os += 0.5, "S-", j, "S+", j + 1
+    os += "Sz", j, "Sz", j + 1
+  end
+  H = MPO(os, s)
+
+  # Correct x
+  x_c = randomMPS(s; linkdims=4)
+
+  b = apply(H, x_c; cutoff)
+
+  #x = linsolve(H, b; cutoff, nsweeps=3, ishermitian=true, outputlevel=2)
+  x0 = copy(b)
+  x = ITensorTDVP.dmrg_linsolve(H, b, b; cutoff, nsweeps=4, ishermitian=true)
+
+  @show linkdims(x)
+  @show norm(apply(H, x) - b)
+  @show norm(apply(H, x_c) - b)
+
+  #@show inner(x,x)
+  #@show inner(x_c,x)/sqrt(inner(x,x))
+
+end
+
+nothing

--- a/test/test_tdvp.jl
+++ b/test/test_tdvp.jl
@@ -116,9 +116,6 @@ end
 
   ψ1 = tdvp(solver, H, -0.1im, ψ0; cutoff, nsite=1)
 
-  @test ψ1 ≈ tdvp(solver, -0.1im, H, ψ0; cutoff, nsite=1)
-  @test ψ1 ≈ tdvp(solver, H, ψ0, -0.1im; cutoff, nsite=1)
-
   @test norm(ψ1) ≈ 1.0
 
   ## Should lose fidelity:


### PR DESCRIPTION
## Description

Adds the `linsolve(A::MPO,b::MPS,x0::MPS)` function and a test.

Additionally this PR does some "plumbing" of the various solver_... keyword args through the generic tdvp engine down to the call of the solver in tdvp_step.jl. This was pretty time consuming to do, so I posted a reply to issue #27 about whether it's worth having this level of detailed plumbing just to ensure a certain kind of error gets thrown (which is of course a worthy goal). There are downsides to the current approach, such as the difficulty of adding new kwargs and relatedly sometimes kwargs not getting passed by accident.

This PR adds the ProjMPS2 and ProjMPO_MPS2 types. The differences
of these from the ProjMPS and ProjMPO_MPS in ITensors.jl are
- both use the AbstractProjMPO interface
- the contract function of ProjMPO_MPS2 does *not* also multiply
  by the ProjMPS2's inside. In the `linsolve` case
  one would not want this. In the "weight penality" DMRG method,
  my thinking is one could multiply by the ProjMPS2's explicitly
  in the solver. To be discussed.
- the ProjMPS2 type does not implement the same kind of `contract`
  as the current ProjMPS, which is fairly special-purpose for the 
  weight-penalty DMRG method. It would be easy enough to implement
  that, but also other methods building off this new design 
  and using the custom solver feature of this package.
