### PR TITLE
Pass `linsolve` kwargs properly

### DIFF
--- a/src/contract_mpo_mps.jl
+++ b/src/contract_mpo_mps.jl
@@ -1,6 +1,6 @@
 function contractmpo_solver(; kwargs...)
   function solver(PH, t, psi; kws...)
-    v = ITensor(1.0)
+    v = ITensor(true)
     for j in (PH.lpos + 1):(PH.rpos - 1)
       v *= PH.psi0[j]
     end

--- a/src/dmrg_x.jl
+++ b/src/dmrg_x.jl
@@ -1,5 +1,5 @@
 function dmrg_x_solver(PH, t, psi0; kwargs...)
-  H = contract(PH, ITensor(1.0))
+  H = contract(PH, ITensor(true))
   D, U = eigen(H; ishermitian=true)
   u = uniqueind(U, H)
   max_overlap, max_ind = findmax(abs, array(psi0 * U))

--- a/src/linsolve.jl
+++ b/src/linsolve.jl
@@ -22,7 +22,7 @@ Keyword arguments:
     See `KrylovKit.jl` documentation for more details on available keyword arguments.
 """
 function linsolve(
-  A::MPO, b::MPS, x₀::MPS, a₀::Number=0, a₁::Number=1; solver_kwargs=(;), tdvp_kwargs...
+  A::MPO, b::MPS, x₀::MPS, a₀::Number=false, a₁::Number=true; solver_kwargs=(;), tdvp_kwargs...
 )
   function linsolve_solver(P::ProjMPO_MPS2, t, x₀; current_time, outputlevel)
     b = dag(only(proj_mps(P)))

--- a/src/linsolve.jl
+++ b/src/linsolve.jl
@@ -10,13 +10,16 @@ system A*x = b.
 
 To adjust the balance between accuracy of solution
 and speed of the algorithm, it is recommed to first try
-adjusting the `solver_tol` keyword argument descibed below.
+adjusting the solver keyword arguments as descibed below.
 
 Keyword arguments:
-  - `ishermitian::Bool=false` - should set to true if the MPO A is Hermitian
-  - `solver_krylovdim::Int=30` - max number of Krylov vectors to build on each solver iteration
-  - `solver_maxiter::Int=100` - max number outer iterations (restarts) to do in the solver step
-  - `solver_tol::Float64=1E-14` - tolerance or error goal of the solver
+  - `nsweeps`, `cutoff`, `maxdim`, etc. (like for other MPO/MPS solvers).
+  - `solver_kwargs=(;)` - a `NamedTuple` containing keyword arguments that will get forwarded to the local solver,
+    in this case `KrylovKit.linsolve` which is a GMRES linear solver. For example:
+    ```juli
+    linsolve(A, b, x; maxdim=100, cutoff=1e-8, nsweeps=10, solver_kwargs=(; ishermitian=true, tol=1e-6, maxiter=20, krylovdim=30))
+    ```
+    See `KrylovKit.jl` documentation for more details on available keyword arguments.
 """
 function linsolve(
   A::MPO, b::MPS, x₀::MPS, a₀::Number=0, a₁::Number=1; solver_kwargs=(;), tdvp_kwargs...

--- a/src/linsolve.jl
+++ b/src/linsolve.jl
@@ -22,7 +22,13 @@ Keyword arguments:
     See `KrylovKit.jl` documentation for more details on available keyword arguments.
 """
 function linsolve(
-  A::MPO, b::MPS, x₀::MPS, a₀::Number=false, a₁::Number=true; solver_kwargs=(;), tdvp_kwargs...
+  A::MPO,
+  b::MPS,
+  x₀::MPS,
+  a₀::Number=false,
+  a₁::Number=true;
+  solver_kwargs=(;),
+  tdvp_kwargs...,
 )
   function linsolve_solver(P::ProjMPO_MPS2, t, x₀; current_time, outputlevel)
     b = dag(only(proj_mps(P)))

--- a/src/linsolve.jl
+++ b/src/linsolve.jl
@@ -18,14 +18,10 @@ Keyword arguments:
   - `solver_maxiter::Int=100` - max number outer iterations (restarts) to do in the solver step
   - `solver_tol::Float64=1E-14` - tolerance or error goal of the solver
 """
-function linsolve(A::MPO, b::MPS, x₀::MPS, a₀::Number=0, a₁::Number=1; solver_kwargs=(;), tdvp_kwargs...)
-  function linsolve_solver(
-    P::ProjMPO_MPS2,
-    t,
-    x₀;
-    current_time,
-    outputlevel,
-  )
+function linsolve(
+  A::MPO, b::MPS, x₀::MPS, a₀::Number=0, a₁::Number=1; solver_kwargs=(;), tdvp_kwargs...
+)
+  function linsolve_solver(P::ProjMPO_MPS2, t, x₀; current_time, outputlevel)
     b = dag(only(proj_mps(P)))
     x, info = KrylovKit.linsolve(P, b, x₀, a₀, a₁; solver_kwargs...)
     return x, nothing

--- a/src/linsolve.jl
+++ b/src/linsolve.jl
@@ -18,25 +18,14 @@ Keyword arguments:
   - `solver_maxiter::Int=100` - max number outer iterations (restarts) to do in the solver step
   - `solver_tol::Float64=1E-14` - tolerance or error goal of the solver
 """
-function linsolve(A::MPO, b::MPS, x₀::MPS, a₀::Number=0, a₁::Number=1; kwargs...)
+function linsolve(A::MPO, b::MPS, x₀::MPS, a₀::Number=0, a₁::Number=1; solver_kwargs=(;), tdvp_kwargs...)
   function linsolve_solver(
     P::ProjMPO_MPS2,
     t,
     x₀;
-    ishermitian=false,
-    solver_tol=1E-14,
-    solver_krylovdim=30,
-    solver_maxiter=100,
-    solver_verbosity=0,
-    kwargs...,
+    current_time,
+    outputlevel,
   )
-    solver_kwargs = (;
-      ishermitian=ishermitian,
-      tol=solver_tol,
-      krylovdim=solver_krylovdim,
-      maxiter=solver_maxiter,
-      verbosity=solver_verbosity,
-    )
     b = dag(only(proj_mps(P)))
     x, info = KrylovKit.linsolve(P, b, x₀, a₀, a₁; solver_kwargs...)
     return x, nothing
@@ -44,5 +33,5 @@ function linsolve(A::MPO, b::MPS, x₀::MPS, a₀::Number=0, a₁::Number=1; kwa
 
   t = Inf
   P = ProjMPO_MPS2(A, b)
-  return tdvp(linsolve_solver, P, t, x₀; reverse_step=false, kwargs...)
+  return tdvp(linsolve_solver, P, t, x₀; reverse_step=false, tdvp_kwargs...)
 end

--- a/src/projmps2.jl
+++ b/src/projmps2.jl
@@ -116,7 +116,7 @@ function proj_mps(P::ProjMPS2)
   end
 
   # Apply the map
-  m = ITensor(1.0)
+  m = ITensor(true)
   for it in itensor_map
     #@show inds(it)
     m *= it

--- a/test/test_linsolve.jl
+++ b/test/test_linsolve.jl
@@ -4,13 +4,13 @@ using Test
 using Random
 
 @testset "Linsolve" begin
-  @testset "Linsolve Basics" begin
+  @testset "Linsolve Basics" for conserve_qns in (false, true)
     cutoff = 1E-11
     maxdim = 8
     nsweeps = 2
 
     N = 8
-    s = siteinds("S=1/2", N; conserve_qns=true)
+    s = siteinds("S=1/2", N; conserve_qns)
 
     os = OpSum()
     for j in 1:(N - 1)
@@ -41,7 +41,8 @@ using Random
     b = apply(H, x_c; cutoff)
 
     x0 = randomMPS(s, state; linkdims=10)
-    x = linsolve(H, b, x0; cutoff, maxdim, nsweeps, ishermitian=true, solver_tol=1E-6)
+    solver_kwargs = (; tol=1e-6)
+    x = linsolve(H, b, x0; cutoff, maxdim, nsweeps, ishermitian=true, solver_kwargs)
 
     @show norm(x - x_c)
     @test norm(x - x_c) < 1E-3

--- a/test/test_linsolve.jl
+++ b/test/test_linsolve.jl
@@ -3,8 +3,10 @@ using ITensorTDVP
 using Test
 using Random
 
-@testset "linsolve with conserve_qns=$conserve_qns and eltype=$eltype" for conserve_qns in (false, true),
+@testset "linsolve with conserve_qns=$conserve_qns and eltype=$eltype" for conserve_qns in
+                                                                           (false, true),
   eltype in (Float32, Float64, ComplexF32, ComplexF64)
+
   N = 6
   s = siteinds("S=1/2", N; conserve_qns)
 

--- a/test/test_linsolve.jl
+++ b/test/test_linsolve.jl
@@ -3,50 +3,47 @@ using ITensorTDVP
 using Test
 using Random
 
-@testset "Linsolve" begin
-  @testset "Linsolve Basics" for conserve_qns in (false, true)
-    cutoff = 1E-11
-    maxdim = 8
-    nsweeps = 2
+@testset "linsolve with conserve_qns=$conserve_qns and eltype=$eltype" for conserve_qns in (false, true),
+  eltype in (Float32, Float64, ComplexF32, ComplexF64)
+  N = 6
+  s = siteinds("S=1/2", N; conserve_qns)
 
-    N = 8
-    s = siteinds("S=1/2", N; conserve_qns)
-
-    os = OpSum()
-    for j in 1:(N - 1)
-      os += 0.5, "S+", j, "S-", j + 1
-      os += 0.5, "S-", j, "S+", j + 1
-      os += "Sz", j, "Sz", j + 1
-    end
-    H = MPO(os, s)
-
-    state = [isodd(n) ? "Up" : "Dn" for n in 1:N]
-
-    ## Correct x is x_c
-    #x_c = randomMPS(s, state; linkdims=4)
-    ## Compute b
-    #b = apply(H, x_c; cutoff)
-
-    #x0 = randomMPS(s, state; linkdims=10)
-    #x = linsolve(H, b, x0; cutoff, maxdim, nsweeps, ishermitian=true, solver_tol=1E-6)
-
-    #@show norm(x - x_c)
-    #@test norm(x - x_c) < 1E-4
-
-    #
-    # Test complex case
-    #
-    Random.seed!(1234)
-    x_c = randomMPS(s, state; linkdims=4) + 0.1im * randomMPS(s, state; linkdims=2)
-    b = apply(H, x_c; cutoff)
-
-    x0 = randomMPS(s, state; linkdims=10)
-    solver_kwargs = (; tol=1e-6)
-    x = linsolve(H, b, x0; cutoff, maxdim, nsweeps, ishermitian=true, solver_kwargs)
-
-    @show norm(x - x_c)
-    @test norm(x - x_c) < 1E-3
+  os = OpSum()
+  for j in 1:(N - 1)
+    os += 0.5, "S+", j, "S-", j + 1
+    os += 0.5, "S-", j, "S+", j + 1
+    os += "Sz", j, "Sz", j + 1
   end
+  H = ITensors.convert_leaf_eltype(eltype, MPO(os, s))
+
+  state = [isodd(n) ? "Up" : "Dn" for n in 1:N]
+
+  Random.seed!(1234)
+  x_c = randomMPS(eltype, s, state; linkdims=2)
+  e, x_c = dmrg(H, x_c; nsweeps=10, cutoff=1e-6, maxdim=20, outputlevel=0)
+
+  @test ITensors.scalartype(x_c) == eltype
+
+  # Compute `b = H * x_c`
+  b = apply(H, x_c; cutoff=1e-8)
+
+  @test ITensors.scalartype(b) == eltype
+
+  # Starting guess
+  x0 = x_c + eltype(0.05) * randomMPS(eltype, s, state; linkdims=2)
+
+  @test ITensors.scalartype(x0) == eltype
+
+  nsweeps = 10
+  cutoff = 1e-5
+  maxdim = 20
+  solver_kwargs = (; tol=1e-4, maxiter=20, krylovdim=30, ishermitian=true)
+  x = @time linsolve(H, b, x0; nsweeps, cutoff, maxdim, solver_kwargs)
+
+  @test ITensors.scalartype(x) == eltype
+
+  @show norm(x - x_c)
+  @test norm(x - x_c) < 1e-2
 end
 
 nothing


### PR DESCRIPTION
@emstoudenmire making a small adjustment to `linsolve` since @hjkqubit is relying on this code and it seems like the keyword arguments weren't getting passed at all to the solver. This follows the design we discussed of passing the solver keyword arguments as a `NamedTuple`, which seems to work well and is simple to implement.