### PR TITLE
Fix `TimeDependentSum`, update for ITensors v0.3.25

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensorTDVP"
 uuid = "25707e16-a4db-4a07-99d9-4d67b7af0342"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org> and contributors"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 ITensors = "9136182c-28ba-11e9-034c-db9fb085ebd5"
@@ -11,7 +11,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [compat]
-ITensors = "0.3.3"
+ITensors = "0.3.25"
 KrylovKit = "0.5, 0.6"
 Observers = "0.0.8"
 TimerOutputs = "0.5"

--- a/src/solver_utils.jl
+++ b/src/solver_utils.jl
@@ -28,7 +28,7 @@ struct TimeDependentSum{S,T}
   f::Vector{S}
   H0::T
 end
-TimeDependentSum(f::Vector, H0::ProjMPOSum) = TimeDependentSum(f, H0.pm)
+TimeDependentSum(f::Vector, H0::ProjMPOSum) = TimeDependentSum(f, ITensors.term(H0))
 Base.length(H::TimeDependentSum) = length(H.f)
 
 function Base.:*(c::Number, H::TimeDependentSum)

--- a/src/solver_utils.jl
+++ b/src/solver_utils.jl
@@ -28,7 +28,7 @@ struct TimeDependentSum{S,T}
   f::Vector{S}
   H0::T
 end
-TimeDependentSum(f::Vector, H0::ProjMPOSum) = TimeDependentSum(f, ITensors.term(H0))
+TimeDependentSum(f::Vector, H0::ProjMPOSum) = TimeDependentSum(f, ITensors.terms(H0))
 Base.length(H::TimeDependentSum) = length(H.f)
 
 function Base.:*(c::Number, H::TimeDependentSum)


### PR DESCRIPTION
Closes #53.