### PR TITLE
Update to Observers v0.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensorTDVP"
 uuid = "25707e16-a4db-4a07-99d9-4d67b7af0342"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org> and contributors"]
-version = "0.1.1"
+version = "0.2.0"
 
 [deps]
 ITensors = "9136182c-28ba-11e9-034c-db9fb085ebd5"
@@ -11,9 +11,9 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [compat]
-ITensors = "0.3.25"
-KrylovKit = "0.5, 0.6"
-Observers = "0.0.8"
+ITensors = "0.3.32"
+KrylovKit = "0.6"
+Observers = "0.1"
 TimerOutputs = "0.5"
 julia = "1.6"
 

--- a/examples/04_tdvp_observers.jl
+++ b/examples/04_tdvp_observers.jl
@@ -64,11 +64,10 @@ psi_f = tdvp(
   (observer!)=obs,
 )
 
-res = results(obs)
-steps = res["steps"]
-times = res["times"]
-psis = res["psis"]
-Sz = res["Sz"]
+steps = obs.steps
+times = obs.times
+psis = obs.psis
+Sz = obs.Sz
 
 println("\nResults")
 println("=======")

--- a/examples/05_tdvp_nonuniform_timesteps.jl
+++ b/examples/05_tdvp_nonuniform_timesteps.jl
@@ -29,9 +29,8 @@ psi = tdvp_nonuniform_timesteps(
   ProjMPO(H), psi0; time_steps, cutoff, outputlevel, (step_observer!)=obs
 )
 
-res = results(obs)
-times = res["times"]
-psis = res["psis"]
+times = obs.times
+psis = obs.psis
 
 println("\nResults")
 println("=======")

--- a/test/test_tdvp.jl
+++ b/test/test_tdvp.jl
@@ -434,12 +434,12 @@ end
     (step_observer!)=step_obs,
   )
 
-  Sz2 = results(obs)["Sz"]
-  En2 = results(obs)["En"]
-  infos = results(obs)["info"]
+  Sz2 = filter(!isnothing, obs.Sz)
+  En2 = filter(!isnothing, obs.En)
+  infos = obs.info
 
-  Sz2_step = results(step_obs)["Sz"]
-  En2_step = results(step_obs)["En"]
+  Sz2_step = step_obs.Sz
+  En2_step = step_obs.En
 
   @test Sz1 ≈ Sz2
   @test En1 ≈ En2


### PR DESCRIPTION
Update to use the new Observers.jl v0.1 that is based on DataFrames.jl, see https://github.com/GTorlai/Observers.jl/pull/11 and https://github.com/GTorlai/Observers.jl/pull/13.