### PR TITLE
Update to Observers v0.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 [compat]
 ITensors = "0.3.32"
 KrylovKit = "0.6"
-Observers = "0.1"
+Observers = "0.2"
 TimerOutputs = "0.5"
 julia = "1.6"
 

--- a/examples/04_tdvp_observers.jl
+++ b/examples/04_tdvp_observers.jl
@@ -48,7 +48,7 @@ function return_state(; psi, bond, half_sweep)
   return nothing
 end
 
-obs = Observer(
+obs = observer(
   "steps" => step, "times" => current_time, "psis" => return_state, "Sz" => measure_sz
 )
 

--- a/examples/05_tdvp_nonuniform_timesteps.jl
+++ b/examples/05_tdvp_nonuniform_timesteps.jl
@@ -19,7 +19,7 @@ outputlevel = 1
 nsteps = 10
 time_steps = [n ≤ 2 ? -0.2im : -0.1im for n in 1:nsteps]
 
-obs = Observer("times" => (; current_time) -> current_time, "psis" => (; psi) -> psi)
+obs = observer("times" => (; current_time) -> current_time, "psis" => (; psi) -> psi)
 
 s = siteinds("S=1/2", N; conserve_qns=true)
 H = MPO(heisenberg(N), s)

--- a/examples/05_utils.jl
+++ b/examples/05_utils.jl
@@ -13,7 +13,7 @@ function tdvp_nonuniform_timesteps(
   reverse_step=true,
   time_start=0.0,
   order=2,
-  (step_observer!)=Observer(),
+  (step_observer!)=observer(),
   kwargs...,
 )
   nsweeps = length(time_steps)

--- a/test/test_tdvp.jl
+++ b/test/test_tdvp.jl
@@ -414,13 +414,13 @@ end
     return info
   end
 
-  obs = Observer("Sz" => measure_sz, "En" => measure_en, "info" => identity_info)
+  obs = observer("Sz" => measure_sz, "En" => measure_en, "info" => identity_info)
 
   step_measure_sz(; psi) = expect(psi, "Sz"; sites=c)
 
   step_measure_en(; psi) = real(inner(psi', H, psi))
 
-  step_obs = Observer("Sz" => step_measure_sz, "En" => step_measure_en)
+  step_obs = observer("Sz" => step_measure_sz, "En" => step_measure_en)
 
   psi2 = MPS(s, n -> isodd(n) ? "Up" : "Dn")
   tdvp(


### PR DESCRIPTION
Update to Observers v0.2 (https://github.com/GTorlai/Observers.jl/pull/15). The main change is that `Observer(...)` constructors were deprecated in favor of `observer(...)`, and the `Observer` type was removed in favor of just using `DataFrame` directly. Mostly it shouldn't be noticeable to users except for how to access data of the result, which follows the `DataFrames` interface.