### PR TITLE
Use StableRNGs.jl to make tests more consistent

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensorTDVP"
 uuid = "25707e16-a4db-4a07-99d9-4d67b7af0342"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org> and contributors"]
-version = "0.4.1"
+version = "0.4.2"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/test/test_contract.jl
+++ b/test/test_contract.jl
@@ -2,6 +2,7 @@
 using ITensors: ITensors, dag, delta, denseblocks
 using ITensors: MPO, OpSum, apply, contract, inner, randomMPS, siteinds, truncate!
 using ITensorTDVP: ITensorTDVP
+using StableRNGs: StableRNG
 using Test: @test, @test_throws, @testset
 @testset "Contract MPO (eltype=$elt, conserve_qns=$conserve_qns)" for elt in (
     Float32, Float64, Complex{Float32}, Complex{Float64}
@@ -10,7 +11,8 @@ using Test: @test, @test_throws, @testset
 
   N = 20
   s = siteinds("S=1/2", N; conserve_qns)
-  psi = randomMPS(elt, s, j -> isodd(j) ? "↑" : "↓"; linkdims=8)
+  rng = StableRNG(1234)
+  psi = randomMPS(rng, elt, s, j -> isodd(j) ? "↑" : "↓"; linkdims=8)
   os = OpSum()
   for j in 1:(N - 1)
     os += 0.5, "S+", j, "S-", j + 1

--- a/test/test_dmrg.jl
+++ b/test/test_dmrg.jl
@@ -1,6 +1,7 @@
 @eval module $(gensym())
 using ITensors: ITensors, MPO, OpSum, inner, randomMPS, siteinds
 using ITensorTDVP: ITensorTDVP
+using StableRNGs: StableRNG
 using Test: @test, @test_throws, @testset
 @testset "DMRG (eltype=$elt, nsite=$nsite, conserve_qns=$conserve_qns)" for elt in (
     Float32, Float64, Complex{Float32}, Complex{Float64}
@@ -18,7 +19,8 @@ using Test: @test, @test_throws, @testset
     os += "Sz", j, "Sz", j + 1
   end
   H = MPO(elt, os, s)
-  psi = randomMPS(elt, s, j -> isodd(j) ? "↑" : "↓"; linkdims=20)
+  rng = StableRNG(1234)
+  psi = randomMPS(rng, elt, s, j -> isodd(j) ? "↑" : "↓"; linkdims=20)
   nsweeps = 10
   maxdim = [10, 20, 40, 100]
   @test_throws ErrorException ITensorTDVP.dmrg(H, psi; maxdim, cutoff, nsite)

--- a/test/test_dmrg_x.jl
+++ b/test/test_dmrg_x.jl
@@ -2,6 +2,7 @@
 using ITensors: ITensors, MPO, MPS, OpSum, ProjMPO, inner, siteinds
 using ITensorTDVP: dmrg_x
 using Random: Random
+using StableRNGs: StableRNG
 using Test: @test, @test_throws, @testset
 @testset "DMRG-X (eltype=$elt, conserve_qns=$conserve_qns)" for elt in (
     Float32, Float64, Complex{Float32}, Complex{Float64}
@@ -27,9 +28,10 @@ using Test: @test, @test_throws, @testset
   Random.seed!(12)
   W = 12
   # Random fields h ∈ [-W, W]
-  h = W * (2 * rand(real(elt), n) .- 1)
+  rng = StableRNG(1234)
+  h = W * (2 * rand(rng, real(elt), n) .- 1)
   H = MPO(elt, heisenberg(n; h), s)
-  initstate = rand(["↑", "↓"], n)
+  initstate = rand(rng, ["↑", "↓"], n)
   ψ = MPS(elt, s, initstate)
   @test_throws ErrorException dmrg_x(H, ψ; nsite=2, maxdim=20, cutoff=1e-10)
   dmrg_x_kwargs = (; nsweeps=20, normalize=true, maxdim=20, cutoff=1e-10, outputlevel=0)

--- a/test/test_tdvp_time_dependent.jl
+++ b/test/test_tdvp_time_dependent.jl
@@ -1,8 +1,9 @@
 @eval module $(gensym())
-using ITensors: ITensors, Index, QN, contract, randomITensor
+using ITensors: ITensors, Index, QN, contract, randomITensor, scalartype
 using ITensors.ITensorMPS: MPO, MPS, ProjMPO, ProjMPOSum, randomMPS, position!, siteinds
 using ITensorTDVP: ITensorTDVP, TimeDependentSum, tdvp
 using LinearAlgebra: norm
+using StableRNGs: StableRNG
 using Test: @test, @test_skip, @testset
 include(joinpath(pkgdir(ITensorTDVP), "examples", "03_models.jl"))
 include(joinpath(pkgdir(ITensorTDVP), "examples", "03_updaters.jl"))
@@ -17,7 +18,8 @@ include(joinpath(pkgdir(ITensorTDVP), "examples", "03_updaters.jl"))
     H = MPO(elt, s, "I")
     H⃗ = (H, H)
     region = 2:3
-    ψ = randomMPS(elt, s, j -> isodd(j) ? "↑" : "↓"; linkdims=2)
+    rng = StableRNG(1234)
+    ψ = randomMPS(rng, elt, s, j -> isodd(j) ? "↑" : "↓"; linkdims=2)
     H⃗ᵣ = ProjMPO.(H⃗)
     map(Hᵣ -> position!(Hᵣ, ψ, first(region)), H⃗ᵣ)
     ∑Hᵣ = ProjMPOSum(collect(H⃗))
@@ -87,10 +89,10 @@ include(joinpath(pkgdir(ITensorTDVP), "examples", "03_updaters.jl"))
       abstol=tol,
     )
 
-    @test ITensors.scalartype(ψ₀) == complex(elt)
-    @test ITensors.scalartype(ψₜ_ode) == complex(elt)
-    @test ITensors.scalartype(ψₜ_krylov) == complex(elt)
-    @test ITensors.scalartype(ψₜ_full) == complex(elt)
+    @test scalartype(ψ₀) == complex(elt)
+    @test scalartype(ψₜ_ode) == complex(elt)
+    @test scalartype(ψₜ_krylov) == complex(elt)
+    @test scalartype(ψₜ_full) == complex(elt)
     @test norm(ψ₀) ≈ 1
     @test norm(ψₜ_ode) ≈ 1
     @test norm(ψₜ_krylov) ≈ 1 rtol = √(eps(real(elt)))


### PR DESCRIPTION
Use [StableRNGs.jl](https://github.com/JuliaRandom/StableRNGs.jl) to make tests relying on randomness more consistent, including across Julia versions (since the default RNG in Julia can, and has, changed across versions).